### PR TITLE
Delete id-fields before queries in POST/PATCH

### DIFF
--- a/server/src/api/jiraconfigurations/jiraconfigurations.controller.ts
+++ b/server/src/api/jiraconfigurations/jiraconfigurations.controller.ts
@@ -3,19 +3,22 @@ import JiraConfiguration from './jiraconfigurations.model';
 
 export const postJiraConfigurations: RouteHandlerFnc = async (ctx, _) => {
   ctx.body = await JiraConfiguration.query().insertAndFetch({
-    ...ctx.request.body,
+    url: ctx.request.body.url,
+    privatekey: ctx.request.body.privatekey,
     roadmapId: Number(ctx.params.roadmapId),
   });
 };
 
 export const patchJiraConfigurations: RouteHandlerFnc = async (ctx, _) => {
-  const { url, privatekey, ...others } = ctx.request.body;
+  const { id, url, privatekey, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
-  const updated = await JiraConfiguration.query().patchAndFetchById(
-    Number(ctx.params.jiraId),
-    { url: url, privatekey: privatekey },
-  );
+  const updated = await JiraConfiguration.query()
+    .patchAndFetchById(Number(ctx.params.jiraId), {
+      url: url,
+      privatekey: privatekey,
+    })
+    .where({ roadmapId: Number(ctx.params.roadmapId) });
 
   if (!updated) {
     return void (ctx.status = 404);

--- a/server/src/api/jiraconfigurations/jiraconfigurations.model.ts
+++ b/server/src/api/jiraconfigurations/jiraconfigurations.model.ts
@@ -1,4 +1,3 @@
-
 import { Model } from 'objection';
 import Roadmap from './../roadmaps/roadmaps.model';
 
@@ -8,6 +7,8 @@ export default class JiraConfiguration extends Model {
   privatekey!: string;
 
   belongsToRoadmap!: Roadmap;
+
+  roadmapId?: number;
 
   static tableName = 'jiraconfigurations';
 

--- a/server/src/api/roadmaps/roadmaps.controller.ts
+++ b/server/src/api/roadmaps/roadmaps.controller.ts
@@ -50,7 +50,7 @@ export const postRoadmaps: RouteHandlerFnc = async (ctx, _) => {
 };
 
 export const patchRoadmaps: RouteHandlerFnc = async (ctx, _) => {
-  const { name, description, ...others } = ctx.request.body;
+  const { id, name, description, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const updated = await Roadmap.query().patchAndFetchById(

--- a/server/src/api/roles/roles.controller.ts
+++ b/server/src/api/roles/roles.controller.ts
@@ -4,14 +4,15 @@ import { Role } from './roles.model';
 
 export const inviteRoadmapUser: RouteHandlerFnc = async (ctx, _) => {
   const created = await Role.query().insertAndFetch({
-    ...ctx.request.body,
+    type: ctx.request.body.type,
+    userId: ctx.request.body.userId,
     roadmapId: Number(ctx.params.roadmapId),
   });
   ctx.body = created;
 };
 
 export const patchRoadmapUserRoles: RouteHandlerFnc = async (ctx, _) => {
-  const { type, ...others } = ctx.request.body;
+  const { id, type, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const patched = await Role.query().patchAndFetchById(

--- a/server/src/api/taskratings/taskratings.controller.ts
+++ b/server/src/api/taskratings/taskratings.controller.ts
@@ -63,7 +63,7 @@ export const patchTaskratings: RouteHandlerFnc = async (ctx, _) => {
   if (!ctx.state.user) {
     throw new Error('User is required');
   }
-  const { value, comment, ...others } = ctx.request.body;
+  const { id, value, comment, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   return await Taskrating.transaction(async (trx) => {

--- a/server/src/api/tasks/tasks.controller.ts
+++ b/server/src/api/tasks/tasks.controller.ts
@@ -28,7 +28,7 @@ export const postTasks: RouteHandlerFnc = async (ctx, _) => {
   if (!ctx.state.user) {
     throw new Error('User is required');
   }
-  const { jiraId, createdAt, ...others } = ctx.request.body;
+  const { jiraId, createdAt, id, ...others } = ctx.request.body;
   const task = await Task.query().insertAndFetch({
     ...others,
     roadmapId: Number(ctx.params.roadmapId),
@@ -59,7 +59,7 @@ export const patchTasks: RouteHandlerFnc = async (ctx, _) => {
   if (!ctx.state.user) {
     throw new Error('User is required');
   }
-  const { name, description, completed, ...others } = ctx.request.body;
+  const { id, name, description, completed, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   return await Task.transaction(async (trx) => {

--- a/server/src/api/users/users.controller.ts
+++ b/server/src/api/users/users.controller.ts
@@ -10,13 +10,14 @@ export const getUsers: RouteHandlerFnc = async (ctx, _) => {
 };
 
 export const postUsers: RouteHandlerFnc = async (ctx, _) => {
-  const inserted = await User.query().insertAndFetch(ctx.request.body);
+  const { id, ...others } = ctx.request.body;
+  const inserted = await User.query().insertAndFetch(others);
 
   ctx.body = inserted;
 };
 
 export const patchUsers: RouteHandlerFnc = async (ctx, _) => {
-  const { username, email, ...others } = ctx.request.body;
+  const { id, username, email, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const updated = await User.query().patchAndFetchById(ctx.params.id, {

--- a/server/src/api/versions/versions.controller.ts
+++ b/server/src/api/versions/versions.controller.ts
@@ -39,7 +39,9 @@ export const postVersions: RouteHandlerFnc = async (ctx, _) => {
     }
 
     return await Version.query().insertAndFetch({
-      ...ctx.request.body,
+      name: ctx.request.body.name,
+      tasks: ctx.request.body.name,
+      sortingRank: ctx.request.body.sortingRank,
       roadmapId: Number(ctx.params.roadmapId),
     });
   });
@@ -68,7 +70,7 @@ export const deleteVersions: RouteHandlerFnc = async (ctx, _) => {
 export const patchVersions: RouteHandlerFnc = async (ctx, _) => {
   let { sortingRank } = ctx.request.body;
   delete ctx.request.body.sortingRank;
-  const { name, tasks, ...others } = ctx.request.body;
+  const { id, name, tasks, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const updated = await Version.transaction(async (trx) => {


### PR DESCRIPTION
- Id's are now allowed, but discarded, in patch routes
- Id's are not used in post/patch queries
- patchCustomer is not modified, since Juho has already done that in customer-model-frontend -branch