### PR TITLE
Change column lengths to match json schema

### DIFF
--- a/server/src/api/users/users.model.ts
+++ b/server/src/api/users/users.model.ts
@@ -34,7 +34,7 @@ export default class User extends Password(Model) {
         maxLength: 255,
       },
       email: { type: 'string', format: 'email', minLength: 1, maxLength: 255 },
-      password: { type: 'string', minLength: 1, maxLength: 255 },
+      password: { type: 'string', minLength: 1, maxLength: 72 },
       authToken: { type: ['string', 'null'], format: 'uuid' },
       type: {
         type: 'integer',

--- a/server/src/migrations/20210531133549_adjustColumnLengthConstraints.ts
+++ b/server/src/migrations/20210531133549_adjustColumnLengthConstraints.ts
@@ -1,0 +1,20 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema
+    .alterTable('users', (table) => {
+      table.string('username', 255).alter();
+      table.string('email', 255).alter();
+    })
+    .alterTable('roadmaps', (table) => {
+      table.string('name', 255).alter();
+    })
+    .alterTable('tasks', (table) => {
+      table.string('name', 255).alter();
+    })
+    .alterTable('customer', (table) => {
+      table.string('name', 255).notNullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<any> {}


### PR DESCRIPTION
The password field is ok, as it is stored hashed.
The hash uses bcrypt, which produces 60 character long hash.

One more consideration is the actual plain text password length. As
bcrypt only uses the first 72 bytes, the length might be good to limit
to more closely reflect the actual usable length.