### PR TITLE
Fix task rating bug

### DIFF
--- a/frontend/src/components/TableTaskRow.tsx
+++ b/frontend/src/components/TableTaskRow.tsx
@@ -22,6 +22,7 @@ import {
   roadmapUsersSelector,
   allCustomersSelector,
 } from '../redux/roadmaps/selectors';
+import { taskAwaitsRatings } from '../utils/TaskUtils';
 import { DeleteButton } from './forms/DeleteButton';
 import { EditButton } from './forms/EditButton';
 import { InfoButton } from './forms/InfoButton';
@@ -251,9 +252,7 @@ export const TableTaskRow: React.FC<TableTaskRowProps> = ({ task }) => {
       </td>
       <td className="styledTd">{new Date(createdAt).toLocaleDateString()}</td>
       <td className="styledTd textAlignEnd nowrap" style={{ width: '202px' }}>
-        {!task.ratings.find(
-          (rating) => rating.createdByUser === userInfo?.id,
-        ) && (
+        {taskAwaitsRatings(task, userInfo) && (
           <a
             href={`?openModal=${
               ModalTypes.TASK_RATINGS_INFO_MODAL

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
 import { RoleType } from '../../../shared/types/customTypes';
+import { taskAwaitsRatings } from '../utils/TaskUtils';
 import { versionsActions } from '../redux/versions';
 import { roadmapsVersionsSelector } from '../redux/versions/selectors';
 import { Version } from '../redux/versions/types';
@@ -51,9 +52,8 @@ export const DashboardPage = () => {
 
   const getUnratedTasks = () => {
     if (!currentRoadmap) return [];
-    return currentRoadmap.tasks.filter(
-      (task) =>
-        !task.ratings.find((rating) => rating.createdByUser === userInfo!.id),
+    return currentRoadmap.tasks.filter((task) =>
+      taskAwaitsRatings(task, userInfo),
     );
   };
 

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -1,7 +1,11 @@
 import { DraggableLocation } from 'react-beautiful-dnd';
 import { Customer, Roadmap, Task, Taskrating } from '../redux/roadmaps/types';
-import { TaskRatingDimension } from '../../../shared/types/customTypes';
 import { customerWeight } from './CustomerUtils';
+import { UserInfo } from '../redux/user/types';
+import {
+  RoleType,
+  TaskRatingDimension,
+} from '../../../shared/types/customTypes';
 import {
   SortingOrders,
   sorted,
@@ -9,6 +13,7 @@ import {
   sortKeyLocale,
   SortComparison,
 } from './SortUtils';
+import { getType } from './UserUtils';
 
 export { SortingOrders } from './SortUtils';
 
@@ -249,4 +254,18 @@ export const calcWeightedTaskPriority = (
   if (!avgWorkRating) return -1;
 
   return weightedValue / avgWorkRating;
+};
+
+export const taskAwaitsRatings = (task: Task, userInfo?: UserInfo) => {
+  const type = getType(userInfo?.roles, task.roadmapId);
+  if (type === RoleType.Admin || type === RoleType.Business)
+    return !!userInfo?.representativeFor?.find(
+      (rep) =>
+        !task.ratings.some(
+          (rating) =>
+            rep.id === rating.forCustomer &&
+            rating.createdByUser === userInfo?.id,
+        ),
+    );
+  return !task.ratings.find((rating) => rating.createdByUser === userInfo?.id);
 };

--- a/server/src/seeds/testdata.ts
+++ b/server/src/seeds/testdata.ts
@@ -4,7 +4,10 @@ import Roadmap from '../api/roadmaps/roadmaps.model';
 import User from '../api/users/users.model';
 import { Role } from '../api/roles/roles.model';
 import Version from '../api/versions/versions.model';
-import { RoleType } from '../../../shared/types/customTypes';
+import {
+  RoleType,
+  TaskRatingDimension,
+} from '../../../shared/types/customTypes';
 import Customer from '../api/customer/customer.model';
 
 export async function seed(knex: Knex): Promise<any> {
@@ -78,7 +81,9 @@ const createTestCustomers = async () => {
 };
 
 const createTestRoadmap = async () => {
-  const firstUserId = (await User.query().first()).id;
+  const developerUserId = (
+    await User.query().findOne('username', 'DeveloperPerson1')
+  ).id;
 
   const testRoadMap = {
     name: 'Test roadmap',
@@ -89,14 +94,14 @@ const createTestRoadmap = async () => {
         name: 'Test task 1',
         description: 'Test desc 1',
         createdBy: {
-          id: firstUserId,
+          id: developerUserId,
         },
         ratings: [
           {
             createdBy: {
-              id: firstUserId,
+              id: developerUserId,
             },
-            dimension: 0,
+            dimension: TaskRatingDimension.RequiredWork,
             value: 5,
           },
         ],
@@ -105,7 +110,7 @@ const createTestRoadmap = async () => {
         name: 'Test task 2',
         description: 'Test desc 2',
         createdBy: {
-          id: firstUserId,
+          id: developerUserId,
         },
       },
     ],

--- a/server/tests/taskratings.test.ts
+++ b/server/tests/taskratings.test.ts
@@ -6,7 +6,11 @@ import Roadmap from '../src/api/roadmaps/roadmaps.model';
 import User from '../src/api/users/users.model';
 import Task from '../src/api/tasks/tasks.model';
 import { Role } from '../src/api/roles/roles.model';
-import { Permission, RoleType } from '../../shared/types/customTypes';
+import {
+  Permission,
+  RoleType,
+  TaskRatingDimension,
+} from '../../shared/types/customTypes';
 import TaskRating from '../src/api/taskratings/taskratings.model';
 
 describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () {
@@ -50,7 +54,7 @@ describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () 
         .post(`/roadmaps/${firstRoadmapId}/tasks/${firstTaskId}/taskratings`)
         .type('json')
         .send({
-          dimension: 1,
+          dimension: TaskRatingDimension.RequiredWork,
           value: 5,
         });
       expect(res.status).to.equal(200);
@@ -75,7 +79,7 @@ describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () 
         .post(`/roadmaps/${firstRoadmapId}/tasks/${firstTaskId}/taskratings`)
         .type('json')
         .send({
-          dimension: 1,
+          dimension: TaskRatingDimension.RequiredWork,
           value: 5,
         });
       expect(res.status).to.equal(403);
@@ -141,7 +145,7 @@ describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () 
           value: 9,
         });
       expect(res.status).to.equal(200);
-      expect(res.body.dimension).to.equal(0);
+      expect(res.body.dimension).to.equal(TaskRatingDimension.RequiredWork);
       expect(res.body.value).to.equal(9);
     });
     it('Should not patch taskrating with incorrect permissions', async function () {
@@ -163,7 +167,7 @@ describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () 
           value: 9,
         });
       expect(res.status).to.equal(403);
-      expect(res.body.dimension).not.to.equal(0);
+      expect(res.body.dimension).not.to.equal(TaskRatingDimension.RequiredWork);
       expect(res.body.value).not.to.equal(9);
     });
   });


### PR DESCRIPTION
Rate-button was missing in tasks page's 'waiting for ratings'-list
and the task was not visible in dashboard, when one of represented
customers rating had already been given.
Business-users had rate-button if they had not rated yet - now it
shows the button if their ratings for represented customers are
missing.
Added a utility function for checking if ratings are needed.