### PR TITLE
Update customer stakes visualization

### DIFF
--- a/frontend/src/components/TableTaskRow.module.scss
+++ b/frontend/src/components/TableTaskRow.module.scss
@@ -26,12 +26,3 @@
 .userIcon {
   color: $COLOR_BLACK60;
 }
-
-.tooltip {
-  @extend .tooltip-base;
-  margin: 0px 0px 10px 0px;
-}
-
-.tooltipArrow {
-  color: white;
-}

--- a/frontend/src/components/TableTaskRow.tsx
+++ b/frontend/src/components/TableTaskRow.tsx
@@ -175,8 +175,8 @@ export const TableTaskRow: React.FC<TableTaskRowProps> = ({ task }) => {
                   <div key={customer.id}>
                     <Tooltip
                       classes={{
-                        arrow: classNames(css.tooltipArrow),
-                        tooltip: classNames(css.tooltip),
+                        arrow: classes(css.tooltipArrow),
+                        tooltip: classes(css.tooltip),
                       }}
                       title={customer.name}
                       placement="top"

--- a/frontend/src/components/TaskValueCreatedVisualization.module.scss
+++ b/frontend/src/components/TaskValueCreatedVisualization.module.scss
@@ -1,9 +1,26 @@
-.container {
-  text-align: start;
+@import './../shared.scss';
+@import './../pages/RoadmapGraphPage.module.scss';
+
+$MAX_DIAMETER: calc(60px * var(--max-diameter-multiplier));
+$DOT_DIAMETER: calc(#{$MAX_DIAMETER} * var(--dot-size, 0));
+$LARGEST_DOT_DIAMETER: calc(#{$MAX_DIAMETER} * var(--largest-dot-size, 0));
+
+.stakes {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-right: calc(
+    var(--version-width) + #{$GRAPH_ITEM_MARGIN} - #{$LARGEST_DOT_DIAMETER}
+  );
 }
 
-.taskTitle {
-  display: inline-block;
-  min-width: 450px;
-  text-align: center;
+.dotContainer {
+  display: flex;
+  justify-content: center;
+  height: $DOT_DIAMETER;
+
+  svg {
+    width: $DOT_DIAMETER;
+    height: $DOT_DIAMETER;
+  }
 }

--- a/frontend/src/pages/RoadmapGraphPage.module.scss
+++ b/frontend/src/pages/RoadmapGraphPage.module.scss
@@ -1,5 +1,7 @@
 @import '../shared.scss';
 
+$GRAPH_ITEM_MARGIN: 11px;
+
 .graphOuter {
   display: flex;
   flex-direction: column;
@@ -62,7 +64,7 @@
   flex-direction: column;
   overflow-x: visible;
   border-radius: 8px;
-  margin-right: 11px;
+  margin-right: $GRAPH_ITEM_MARGIN;
   padding: 8px;
   background-color: white;
   cursor: pointer;
@@ -82,6 +84,12 @@
   min-height: 200px;
   margin-left: 20px;
   margin-bottom: 45px;
+}
+
+.stakesContainer {
+  display: flex;
+  flex-direction: row;
+  margin-left: 24px;
 }
 
 .versionData {

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -101,9 +101,11 @@ export const RoadmapGraphPage = () => {
         <h2 className={classes(css.graphTitle, css.lowerGraphTitle)}>
           Customers stakes in milestone
         </h2>
-        {selectedVersion && (
-          <TaskValueCreatedVisualization version={selectedVersion} />
-        )}
+        <div className={classes(css.stakesContainer)}>
+          {roadmapsVersions?.map((ver) => (
+            <TaskValueCreatedVisualization version={ver} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -313,6 +313,15 @@ form {
   margin: 0px 10px;
 }
 
+.tooltip {
+  @extend .tooltip-base;
+  margin: 0px 0px 10px 0px;
+}
+
+.tooltipArrow {
+  color: white;
+}
+
 @mixin landing-content-padding {
   padding-left: max(calc((100% - 1000px) / 2), 8vw);
   padding-right: max(calc((100% - 1000px) / 2), 8vw);


### PR DESCRIPTION
The commit message explains this feature in more detail.
Here's screenshots of some examples to get an idea of how it looks:
![ex02](https://user-images.githubusercontent.com/80758782/124735675-ee012f00-df1e-11eb-82f4-2dbe8ec717de.PNG)
![ex07](https://user-images.githubusercontent.com/80758782/124736024-46383100-df1f-11eb-8b2f-751d0e248a37.PNG)
![ex08](https://user-images.githubusercontent.com/80758782/124736030-489a8b00-df1f-11eb-9a95-1be5d50fae96.PNG)

