### PR TITLE
Modify client weighting

### DIFF
--- a/frontend/src/components/TaskValueCreatedVisualization.tsx
+++ b/frontend/src/components/TaskValueCreatedVisualization.tsx
@@ -9,6 +9,7 @@ import { RootState } from '../redux/types';
 import { Version } from '../redux/versions/types';
 import { Dot } from './Dot';
 import { totalValueAndWork } from '../utils/TaskUtils';
+import { percent } from '../utils/string';
 import css from './TaskValueCreatedVisualization.module.scss';
 
 const classes = classNames.bind(css);
@@ -58,14 +59,6 @@ export const TaskValueCreatedVisualization: React.FC<{
       color: key.color,
     }));
 
-  const valuePercent = (value: number) => {
-    const percent = (100 * value) / totalValue;
-    return `${percent.toLocaleString(undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 1,
-    })}%`;
-  };
-
   const largestValue = (stakes: DataPoint[]) => {
     if (!stakes.length) return 0;
     return stakes[0].value / totalValue;
@@ -90,7 +83,9 @@ export const TaskValueCreatedVisualization: React.FC<{
               arrow: classes(css.tooltipArrow),
               tooltip: classes(css.tooltip),
             }}
-            title={`${entry.name} : ${valuePercent(entry.value)}`}
+            title={`${entry.name} : ${percent(1).format(
+              entry.value / totalValue,
+            )}`}
             placement="right"
             arrow
           >

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -90,6 +90,10 @@ export const english = {
     'Predicted milestone durations': 'Predicted milestone durations',
     'Set different weighting for clients':
       'Set different weighting for clients',
+    'Weighting description':
+      "Client weights affect the scaling of milestone's total values in roadmap graph. Weight of 0% will ignore the ratings of the client in question.",
+    'Weighting instructions':
+      'The effects of different weighting can be explored without saving.',
     'Client Weights': 'Client Weights',
     register: 'register',
     'New here?': 'New here?',

--- a/frontend/src/pages/PlannerWeightsPage.module.scss
+++ b/frontend/src/pages/PlannerWeightsPage.module.scss
@@ -13,6 +13,13 @@
   margin-bottom: 35px;
 }
 
+.description {
+  text-align: start;
+  margin-left: 28px;
+  margin-bottom: 30px;
+  max-width: 560px;
+}
+
 .userRow {
   display: flex;
   flex-direction: row;

--- a/frontend/src/pages/PlannerWeightsPage.tsx
+++ b/frontend/src/pages/PlannerWeightsPage.tsx
@@ -32,6 +32,7 @@ export const PlannerWeightsPage = () => {
 
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [noChanges, setNoChanges] = useState(true);
 
   useEffect(() => {
     if (!customers) dispatch(roadmapsActions.getCustomers());
@@ -40,6 +41,15 @@ export const PlannerWeightsPage = () => {
   const resetWeights = () => {
     dispatch(roadmapsActions.clearPlannerCustomerWeights());
   };
+
+  useEffect(() => {
+    setNoChanges(
+      !customerWeights.filter(({ customerId, weight }) => {
+        const saved = customers?.find(({ id }) => id === customerId)?.weight;
+        return weight !== saved;
+      }).length,
+    );
+  }, [customerWeights, customers]);
 
   const saveWeights = () => {
     if (saving) return;
@@ -86,7 +96,7 @@ export const PlannerWeightsPage = () => {
           className="button-small-outlined"
           type="button"
           onClick={resetWeights}
-          disabled={saving}
+          disabled={saving || noChanges}
         >
           Reset
         </button>
@@ -94,7 +104,7 @@ export const PlannerWeightsPage = () => {
           className="button-small-filled"
           type="submit"
           onClick={saveWeights}
-          disabled={saving}
+          disabled={saving || noChanges}
         >
           Save
         </button>
@@ -107,6 +117,14 @@ export const PlannerWeightsPage = () => {
       >
         {errorMessage}
       </Alert>
+      <div className={classes(css.description)}>
+        <p>
+          <Trans i18nKey="Weighting description" />
+        </p>
+        <p>
+          <Trans i18nKey="Weighting instructions" />
+        </p>
+      </div>
       {customers?.map((customer) => (
         <div className={classes(css.userRow)} key={customer.id}>
           <div className={classes(css.customerDot)}>
@@ -118,11 +136,12 @@ export const PlannerWeightsPage = () => {
             name="weight"
             className={classes(css.slider)}
             min={0}
-            max={5}
+            max={2}
             value={customerWeight(customer, customerWeights)}
             defaultValue={customerWeight(customer, customerWeights)}
-            step={1}
+            step={0.25}
             valueLabelDisplay="auto"
+            valueLabelFormat={(value) => `${value * 100}%`}
             marks
             onChange={(e, value) =>
               handleSliderChange(customer.id, Number(value))

--- a/frontend/src/pages/PlannerWeightsPage.tsx
+++ b/frontend/src/pages/PlannerWeightsPage.tsx
@@ -14,6 +14,7 @@ import { Dot } from '../components/Dot';
 import { StoreDispatchType } from '../redux';
 import { roadmapsActions } from '../redux/roadmaps';
 import { customerWeight } from '../utils/CustomerUtils';
+import { percent } from '../utils/string';
 import css from './PlannerWeightsPage.module.scss';
 
 const classes = classNames.bind(css);
@@ -44,10 +45,10 @@ export const PlannerWeightsPage = () => {
 
   useEffect(() => {
     setNoChanges(
-      !customerWeights.filter(({ customerId, weight }) => {
+      !customerWeights.some(({ customerId, weight }) => {
         const saved = customers?.find(({ id }) => id === customerId)?.weight;
         return weight !== saved;
-      }).length,
+      }),
     );
   }, [customerWeights, customers]);
 
@@ -141,7 +142,7 @@ export const PlannerWeightsPage = () => {
             defaultValue={customerWeight(customer, customerWeights)}
             step={0.25}
             valueLabelDisplay="auto"
-            valueLabelFormat={(value) => `${value * 100}%`}
+            valueLabelFormat={(value) => percent().format(value)}
             marks
             onChange={(e, value) =>
               handleSliderChange(customer.id, Number(value))

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -1,2 +1,5 @@
 export const titleCase = (s: string): string =>
   s.substr(0, 1).toLocaleUpperCase() + s.substr(1);
+
+export const percent = (maximumFractionDigits?: number) =>
+  new Intl.NumberFormat(undefined, { style: 'percent', maximumFractionDigits });

--- a/server/src/api/customer/customer.model.ts
+++ b/server/src/api/customer/customer.model.ts
@@ -21,7 +21,7 @@ export default class Customer extends Model {
       id: { type: 'integer' },
       name: { type: 'string', minLength: 1, maxLength: 255 },
       email: { type: 'string', format: 'email', minLength: 1, maxLength: 255 },
-      weight: { type: 'integer', minimum: 0, maximum: 5 },
+      weight: { type: 'float', minimum: 0, maximum: 2 },
       color: { type: 'string', pattern: '^#[0-9a-fA-F]{6}$' },
     },
   };

--- a/server/src/migrations/20210715135729_customerWeightToFloat.ts
+++ b/server/src/migrations/20210715135729_customerWeightToFloat.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.alterTable('customer', (table) => {
+    table.float('weight').notNullable().defaultTo(1).alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.alterTable('customer', (table) => {
+    table.integer('weight').notNullable().defaultTo(0).alter();
+  });
+}


### PR DESCRIPTION
Added a description to client weights page and adjusted the range of the slider to [0,2].
Modified database to use float type for customer weight.

Reset and save buttons are now disabled when no changes to customer weight have been made.

Slider labels are now not displayed with the exception of value 0. I'm not sure if I recall correctly how they were supposed to work and if the current implementation is good at all.