### PR TITLE
Fix rating customers bug

### DIFF
--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -134,7 +134,8 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
       if (a.id === undefined && b.id !== undefined) return -1;
       if (b.id === undefined && a.id !== undefined) return 1;
       return 0;
-    });
+    })
+    .filter((rating) => rating.customer?.roadmapId === task.roadmapId);
 
   const [businessValueRatings, setBusinessValueRatings] = useState(ratings);
   const [businessRatingModified, setBusinessRatingModified] = useState(false);

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -354,14 +354,16 @@ export const unratedTasksAmount = (
 export const taskAwaitsRatings = (task: Task, userInfo?: UserInfo) => {
   const type = getType(userInfo?.roles, task.roadmapId);
   if (type === RoleType.Admin || type === RoleType.Business)
-    return !!userInfo?.representativeFor?.find(
-      (customer) =>
-        !task.ratings.some(
-          (rating) =>
-            customer.id === rating.forCustomer &&
-            rating.createdByUser === userInfo?.id,
-        ),
-    );
+    return !!userInfo?.representativeFor
+      ?.filter((customer) => customer.roadmapId === task.roadmapId)
+      ?.find(
+        (customer) =>
+          !task.ratings.some(
+            (rating) =>
+              customer.id === rating.forCustomer &&
+              rating.createdByUser === userInfo?.id,
+          ),
+      );
   return !task.ratings.find((rating) => rating.createdByUser === userInfo?.id);
 };
 


### PR DESCRIPTION
Rate modal in task table would show customers from every roadmap if you represented them instead of showing the ones that belong to the chosen roadmap.