### PR TITLE
Add scaling to RoadmapGraphPage's total values

### DIFF
--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -1,21 +1,34 @@
 import React, { useEffect, useState } from 'react';
-import { shallowEqual, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import classNames from 'classnames';
 import ListIcon from '@material-ui/icons/List';
+import { StoreDispatchType } from '../redux';
 import { RootState } from '../redux/types';
 import { roadmapsVersionsSelector } from '../redux/versions/selectors';
 import { Version } from '../redux/versions/types';
-import { totalValueAndWork } from '../utils/TaskUtils';
+import { totalWeightedValueAndWork } from '../utils/TaskUtils';
 import { TaskValueCreatedVisualization } from '../components/TaskValueCreatedVisualization';
 import css from './RoadmapGraphPage.module.scss';
 import {
   BusinessValueFilled,
   RequiredWorkFilled,
 } from '../components/RatingIcons';
+import {
+  allCustomersSelector,
+  chosenRoadmapSelector,
+} from '../redux/roadmaps/selectors';
+import { Customer, Roadmap } from '../redux/roadmaps/types';
+import { roadmapsActions } from '../redux/roadmaps';
 
 const classes = classNames.bind(css);
 
+interface VersionWorkAndValue extends Version {
+  work: number;
+  value: number;
+}
+
 export const RoadmapGraphPage = () => {
+  const dispatch = useDispatch<StoreDispatchType>();
   const roadmapsVersions = useSelector<RootState, Version[] | undefined>(
     roadmapsVersionsSelector,
     shallowEqual,
@@ -23,6 +36,40 @@ export const RoadmapGraphPage = () => {
   const [selectedVersion, setSelectedVersion] = useState<undefined | Version>(
     undefined,
   );
+  const [versions, setVersions] = useState<undefined | VersionWorkAndValue[]>(
+    undefined,
+  );
+  const customers = useSelector<RootState, Customer[] | undefined>(
+    allCustomersSelector,
+    shallowEqual,
+  );
+  const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
+    chosenRoadmapSelector,
+    shallowEqual,
+  );
+
+  useEffect(() => {
+    if (!customers) dispatch(roadmapsActions.getCustomers());
+  }, [dispatch, customers]);
+
+  useEffect(() => {
+    if (!currentRoadmap) dispatch(roadmapsActions.getRoadmaps());
+  }, [dispatch, currentRoadmap]);
+
+  useEffect(() => {
+    if (currentRoadmap)
+      setVersions(
+        roadmapsVersions?.map((version) => ({
+          ...version,
+          ...totalWeightedValueAndWork(
+            version.tasks,
+            customers ?? [],
+            currentRoadmap,
+          ),
+        })),
+      );
+  }, [currentRoadmap, customers, roadmapsVersions]);
+
   useEffect(() => {
     if (
       selectedVersion === undefined &&
@@ -44,11 +91,10 @@ export const RoadmapGraphPage = () => {
         <h2 className={classes(css.graphTitle)}>Work / Value</h2>
         <div className={classes(css.graphInner)}>
           <div className={classes(css.graphItems)}>
-            {roadmapsVersions?.map((ver) => {
+            {versions?.map((ver) => {
               const numTasks = ver.tasks.length;
-              const { value, work } = totalValueAndWork(ver.tasks);
-              const w = Math.max(100, 60 * (work / 5));
-              const h = Math.max(100, 60 * (value / 5));
+              const w = Math.max(100, 60 * (ver.work / 5));
+              const h = Math.min(350, Math.max(100, 45 * Math.log2(ver.value)));
               return (
                 <div
                   className={classes(css.graphItem, {
@@ -64,11 +110,11 @@ export const RoadmapGraphPage = () => {
                   <div className={classes(css.versionData)}>
                     <div className={classes(css.ratingDiv)}>
                       <BusinessValueFilled />
-                      <p>{numFormat.format(value)}</p>
+                      <p>{numFormat.format(ver.value)}</p>
                     </div>
                     <div className={classes(css.ratingDiv)}>
                       <RequiredWorkFilled />
-                      <p>{numFormat.format(work)}</p>
+                      <p>{numFormat.format(ver.work)}</p>
                     </div>
                     <div className={classes(css.dash)} />
                     <div className={classes(css.ratingDiv)}>
@@ -98,7 +144,7 @@ export const RoadmapGraphPage = () => {
         </h2>
         <div className={classes(css.stakesContainer)}>
           {roadmapsVersions?.map((ver) => (
-            <TaskValueCreatedVisualization version={ver} />
+            <TaskValueCreatedVisualization version={ver} key={ver.id} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Multiply a client's ratings by their weight (or planner weight) before calculating the taskrating total value.

The scaled total value is displayed only in the roadmap graph versions. Should it be displayed in milestones editor too?
<img src="https://user-images.githubusercontent.com/80758782/126476222-5efbcaa8-33c7-4e10-8b9d-fee7fb02b2df.png" width="400"> <img src="https://user-images.githubusercontent.com/80758782/126476562-469d53f2-45b5-4882-8444-46d5409cc560.png" width="400">


Height is calculated logarithmically: the full height of 350 is reached when a version's total value is a bit over 200.
`const h = Math.min(350, Math.max(100, 45 * Math.log2(ver.value)));`