### PR TITLE
Add notification modal for missing ratings

### DIFF
--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -306,6 +306,18 @@ const patchIntegrationConfiguration = async (
   return response.data as IntegrationConfiguration;
 };
 
+const sendNotification = async (
+  users: number[],
+  task: Task,
+  message: string,
+) => {
+  const response = await axios.post(
+    `roadmaps/${task.roadmapId}/tasks/${task.id}/notify`,
+    { users, message },
+  );
+  return response.status === 200;
+};
+
 export const api = {
   getRoadmaps,
   addRoadmap,
@@ -342,4 +354,5 @@ export const api = {
   swapIntegrationOAuthToken,
   addIntegrationConfiguration,
   patchIntegrationConfiguration,
+  sendNotification,
 };

--- a/frontend/src/components/TableUnratedTaskRow.tsx
+++ b/frontend/src/components/TableUnratedTaskRow.tsx
@@ -124,7 +124,8 @@ export const TableUnratedTaskRow: FC<TableTaskRowProps> = ({ task }) => {
       | ModalTypes.EDIT_TASK_MODAL
       | ModalTypes.RATE_TASK_MODAL
       | ModalTypes.TASK_RATINGS_INFO_MODAL
-      | ModalTypes.TASK_INFO_MODAL,
+      | ModalTypes.TASK_INFO_MODAL
+      | ModalTypes.NOTIFY_USERS_MODAL,
   ) => (e: SyntheticEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -209,7 +210,7 @@ export const TableUnratedTaskRow: FC<TableTaskRowProps> = ({ task }) => {
             style={{ marginRight: '10px' }}
             className={classes(css['button-small-outlined'])}
             type="button"
-            /* onClick={openModal(ModalTypes.NOTIFY_USERS_MODAL)} */
+            onClick={openModal(ModalTypes.NOTIFY_USERS_MODAL)}
           >
             <Trans i18nKey="Notify" />
           </button>

--- a/frontend/src/components/modals/ModalRoot.tsx
+++ b/frontend/src/components/modals/ModalRoot.tsx
@@ -25,6 +25,7 @@ import { TaskInfoModal } from './TaskInfoModal';
 import { TaskRatingsInfoModal } from './TaskRatingsInfoModal';
 import { UserAuthTokenModal } from './UserAuthTokenModal';
 import { AddRoadmapModal } from './AddRoadmapModal';
+import { NotifyUsersModal } from './NotifyUsersModal';
 
 const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.ADD_TASK_MODAL]: AddTaskModal,
@@ -45,6 +46,7 @@ const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.USER_AUTH_TOKEN_MODAL]: UserAuthTokenModal,
   [ModalTypes.ADD_ROADMAP_MODAL]: AddRoadmapModal,
   [ModalTypes.DELETE_ROADMAP_MODAL]: DeleteRoadmapModal,
+  [ModalTypes.NOTIFY_USERS_MODAL]: NotifyUsersModal,
 } as const;
 
 // TODO: move this to css file

--- a/frontend/src/components/modals/NotifyUsersModal.module.scss
+++ b/frontend/src/components/modals/NotifyUsersModal.module.scss
@@ -1,0 +1,16 @@
+@import '../../shared.scss';
+
+.subtitle {
+  @extend .typography-pre-title;
+  color: $COLOR_AZURE;
+}
+
+.message {
+  @extend .subtitle;
+  margin-top: 20px;
+}
+
+hr {
+  color: $COLOR_BLACK5;
+  width: 458px;
+}

--- a/frontend/src/components/modals/NotifyUsersModal.tsx
+++ b/frontend/src/components/modals/NotifyUsersModal.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useEffect } from 'react';
+import { Alert, Form } from 'react-bootstrap';
+import { Trans } from 'react-i18next';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import classNames from 'classnames';
+import { roadmapsActions } from '../../redux/roadmaps';
+import { StoreDispatchType } from '../../redux';
+import {
+  allCustomersSelector,
+  roadmapUsersSelector,
+  taskSelector,
+} from '../../redux/roadmaps/selectors';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { ModalContent } from './modalparts/ModalContent';
+import { ModalFooter } from './modalparts/ModalFooter';
+import { ModalFooterButtonDiv } from './modalparts/ModalFooterButtonDiv';
+import { ModalHeader } from './modalparts/ModalHeader';
+import { Checkbox } from '../forms/Checkbox';
+import { RootState } from '../../redux/types';
+import { UserInfo } from '../../redux/user/types';
+import { userInfoSelector } from '../../redux/user/selectors';
+import { Customer, RoadmapUser } from '../../redux/roadmaps/types';
+import { RoleType } from '../../../../shared/types/customTypes';
+import css from './NotifyUsersModal.module.scss';
+import { getType } from '../../utils/UserUtils';
+import { Modal, ModalTypes } from './types';
+import {
+  findMissingCustomers,
+  findMissingDevelopers,
+} from '../../utils/TaskUtils';
+import { TextArea } from '../forms/FormField';
+
+const classes = classNames.bind(css);
+
+interface CheckableUser extends RoadmapUser {
+  checked: boolean;
+}
+
+export const NotifyUsersModal: Modal<ModalTypes.NOTIFY_USERS_MODAL> = ({
+  closeModal,
+  taskId,
+}) => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const task = useSelector(taskSelector(taskId))!;
+  const [isLoading, setIsLoading] = useState(false);
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const customers = useSelector<RootState, Customer[] | undefined>(
+    allCustomersSelector(),
+    shallowEqual,
+  );
+  const allUsers = useSelector<RootState, RoadmapUser[] | undefined>(
+    roadmapUsersSelector(),
+    shallowEqual,
+  );
+  const [missingUsers, setMissingUsers] = useState<CheckableUser[] | undefined>(
+    [],
+  );
+  const [previousUsers, setPreviousUsers] = useState<
+    CheckableUser[] | undefined
+  >([]);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [message, setMessage] = useState('');
+  const [allChecked, setAllChecked] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (
+      getType(userInfo?.roles, task.roadmapId) === RoleType.Admin &&
+      customers &&
+      allUsers
+    ) {
+      const missingCustomers = findMissingCustomers(task.ratings, customers);
+      const missingRepresentatives = new Map<number, CheckableUser>();
+
+      // Find representatives who haven't given ratings
+      missingCustomers.forEach((customer) => {
+        const ratingsForTask = task.ratings
+          .filter((rating) => rating.forCustomer === customer.id)
+          .map((e) => e.createdByUser);
+
+        // Filter out logged in user, so they won't send email to themselves
+        const representatives = customer.representatives?.filter(
+          (user) => user.id !== userInfo?.id,
+        );
+
+        representatives?.forEach((rep) => {
+          if (
+            !ratingsForTask.includes(rep.id) &&
+            !missingRepresentatives.has(rep.id)
+          )
+            missingRepresentatives.set(rep.id, {
+              ...rep,
+              checked: false,
+            });
+        });
+      });
+
+      const missingDevelopers = findMissingDevelopers(
+        task.ratings,
+        allUsers,
+      ).map((dev) => ({ ...dev, checked: false }));
+
+      setMissingUsers([
+        ...Array.from(missingRepresentatives.values()),
+        ...missingDevelopers,
+      ]);
+    }
+  }, [allUsers, customers, task.ratings, task.roadmapId, userInfo]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsLoading(true);
+
+    const usersToNotify = missingUsers
+      ?.filter((user) => user.checked)
+      .map((user) => user.id);
+
+    if (usersToNotify) {
+      const res = await dispatch(
+        roadmapsActions.notifyUsers({
+          users: usersToNotify,
+          task,
+          message,
+        }),
+      );
+      setIsLoading(false);
+      if (roadmapsActions.notifyUsers.rejected.match(res)) {
+        if (res.payload) setErrorMessage(res.payload.message);
+        return;
+      }
+      closeModal();
+    }
+  };
+
+  const checkAll = (checked: boolean) => {
+    if (!missingUsers) return;
+    if (!checked) setMissingUsers(previousUsers);
+    if (checked) {
+      const copy = [...missingUsers];
+      setPreviousUsers(copy);
+      setMissingUsers(copy.map((user) => ({ ...user, checked })));
+    }
+    setAllChecked(!allChecked);
+  };
+
+  const checkUser = (checked: boolean, idx: number) => {
+    if (!missingUsers) return;
+    const copy = [...missingUsers];
+    copy[idx].checked = checked;
+    setMissingUsers(copy);
+    setAllChecked(checked && copy.every((user) => user.checked));
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <ModalHeader closeModal={closeModal}>
+        <h3>
+          <Trans i18nKey="Send notification by email" />
+        </h3>
+      </ModalHeader>
+      <ModalContent>
+        <p className={classes(css.subtitle)}>
+          <Trans i18nKey="Send the notification to" />
+        </p>
+        <Checkbox
+          label="All"
+          checked={allChecked}
+          onChange={(checked) => checkAll(checked)}
+        />
+        <hr />
+        {missingUsers?.map((user, idx) => (
+          <Checkbox
+            key={user.id}
+            label={user.username}
+            checked={user.checked}
+            onChange={(checked) => checkUser(checked, idx)}
+          />
+        ))}
+        <p className={classes(css.message)}>
+          <Trans i18nKey="Optional message" />
+        </p>
+        <Form.Group>
+          <TextArea
+            name="notificationMessage"
+            id="notificationMessage"
+            draggable="false"
+            placeholder="-"
+            value={message}
+            onChange={(e) => setMessage(e.currentTarget.value)}
+          />
+        </Form.Group>
+        <Alert
+          show={errorMessage.length > 0}
+          variant="danger"
+          dismissible
+          onClose={() => setErrorMessage('')}
+        >
+          {errorMessage}
+        </Alert>
+      </ModalContent>
+      <ModalFooter>
+        <ModalFooterButtonDiv>
+          <button
+            className="button-large cancel"
+            type="button"
+            onClick={() => closeModal()}
+          >
+            <Trans i18nKey="Cancel" />
+          </button>
+        </ModalFooterButtonDiv>
+        <ModalFooterButtonDiv>
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <button
+              className="button-large"
+              type="submit"
+              disabled={!missingUsers?.some((user) => user.checked)}
+            >
+              <Trans i18nKey="Confirm" />
+            </button>
+          )}
+        </ModalFooterButtonDiv>
+      </ModalFooter>
+    </Form>
+  );
+};

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -24,6 +24,7 @@ export enum ModalTypes {
   USER_AUTH_TOKEN_MODAL = 'USER_AUTH_TOKEN_MODAL',
   ADD_ROADMAP_MODAL = 'ADD_ROADMAP_MODAL',
   DELETE_ROADMAP_MODAL = 'DELETE_ROADMAP_MODAL',
+  NOTIFY_USERS_MODAL = 'NOTIFY_USERS_MODAL',
 }
 
 type OwnProps = {
@@ -66,6 +67,7 @@ type OwnProps = {
   [ModalTypes.DELETE_ROADMAP_MODAL]: {
     id: number;
   };
+  [ModalTypes.NOTIFY_USERS_MODAL]: { taskId: number };
 };
 
 type Props = {

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -186,5 +186,6 @@ export const english = {
     workValueTitle: 'Work / Value',
     customerStakesTitle: 'Customer stakes in milestone',
     unratedTaskMessage: 'Waiting for ratings',
+    'Optional message': 'Optional message',
   },
 };

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -500,3 +500,16 @@ export const removeTaskFromVersion = createAsyncThunk<
     }
   },
 );
+
+export const notifyUsers = createAsyncThunk<
+  boolean,
+  { users: number[]; task: Task; message: string },
+  { rejectValue: AxiosError }
+>('notify', async (notificationRequest, thunkAPI) => {
+  const { users, task, message } = notificationRequest;
+  try {
+    return await api.sendNotification(users, task, message);
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err);
+  }
+});

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -26,6 +26,7 @@ import {
   getVersions,
   patchVersion,
   removeTaskFromVersion,
+  notifyUsers,
 } from './actions';
 import {
   ADD_ROADMAP_FULFILLED,
@@ -132,4 +133,5 @@ export const roadmapsActions = {
   deleteVersion,
   addTaskToVersion,
   removeTaskFromVersion,
+  notifyUsers,
 };

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -383,3 +383,33 @@ export const unratedProductOwnerTasks: (
   });
   return unrated;
 };
+
+export const findMissingDevelopers = (
+  taskRatings: Taskrating[],
+  allUsers: RoadmapUser[],
+) => {
+  const ratingIds = taskRatings.map((rating) => rating.createdByUser);
+  return allUsers.filter(
+    (user) => user.type === RoleType.Developer && !ratingIds.includes(user.id),
+  );
+};
+
+export const findMissingCustomers = (
+  taskRatings: Taskrating[],
+  customers: Customer[],
+) => {
+  const ratings = taskRatings.map((rating) => ({
+    createdByUser: rating.createdByUser,
+    forCustomer: rating.forCustomer,
+  }));
+  return customers?.filter((customer) => {
+    const representativeIds = customer?.representatives?.map((rep) => rep.id);
+    return !representativeIds?.every((rep) => {
+      return ratings.some((rating) => {
+        if (rating.createdByUser === rep && rating.forCustomer === customer.id)
+          return true;
+        return false;
+      });
+    });
+  });
+};

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -398,17 +398,12 @@ export const findMissingCustomers = (
   taskRatings: Taskrating[],
   customers: Customer[],
 ) => {
-  const ratings = taskRatings.map((rating) => ({
-    createdByUser: rating.createdByUser,
-    forCustomer: rating.forCustomer,
-  }));
   return customers?.filter((customer) => {
-    const representativeIds = customer?.representatives?.map((rep) => rep.id);
-    return !representativeIds?.every((rep) => {
-      return ratings.some((rating) => {
-        if (rating.createdByUser === rep && rating.forCustomer === customer.id)
-          return true;
-        return false;
+    return !customer.representatives?.every((rep) => {
+      return taskRatings.some((rating) => {
+        return (
+          rating.createdByUser === rep.id && rating.forCustomer === customer.id
+        );
       });
     });
   });


### PR DESCRIPTION
Notifications modal for users that haven't given ratings when they should (it parses out logged in user, I figured that you don't want to send email to yourself). 
Currently it sends the api request to missing endpoint so it should give 404. 
Payload contains: List of users that were checked and the correct task.