### PR TITLE
Task rating

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
@@ -41,7 +42,6 @@
     "react-dom": "^17.0.2",
     "react-i18next": "^11.11.3",
     "react-modal": "^3.14.3",
-    "react-rating": "^2.0.5",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/frontend/src/components/RatingBars.module.scss
+++ b/frontend/src/components/RatingBars.module.scss
@@ -1,0 +1,36 @@
+@import '../shared.scss';
+
+.ratingBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  .rating {
+    @extend .typography-body-bold;
+  }
+
+  .unrated {
+    @extend .typography-body;
+    color: $COLOR_BLACK40;
+  }
+
+  .icon {
+    padding-right: 17.5px;
+    svg {
+      height: 22.5px;
+      width: 22.5px;
+    }
+  }
+
+  .iconFilled path {
+    fill: $COLOR_AZURE;
+  }
+
+  .iconEmpty path {
+    fill: $COLOR_BLACK10;
+  }
+
+  .iconActive {
+    transform: none;
+  }
+}

--- a/frontend/src/components/RatingBars.tsx
+++ b/frontend/src/components/RatingBars.tsx
@@ -1,12 +1,11 @@
-import { FC } from 'react';
-import Rating from 'react-rating';
+import { FC, useState } from 'react';
+import classNames from 'classnames';
+import { Rating as MaterialRating } from '@material-ui/lab';
 import { TaskRatingDimension } from '../../../shared/types/customTypes';
-import {
-  BusinessValueEmpty,
-  BusinessValueFilled,
-  RequiredWorkEmpty,
-  RequiredWorkFilled,
-} from './RatingIcons';
+import { RequiredWorkEmpty, BusinessValueEmpty } from './RatingIcons';
+import css from './RatingBars.module.scss';
+
+const classes = classNames.bind(css);
 
 interface RatingBarProps {
   onChange?: (value: number) => void;
@@ -21,27 +20,39 @@ export const TaskRatingBar: FC<RatingBarProps> = ({
   initialValue,
   readonly,
 }) => {
+  const [hover, setHover] = useState(0);
+
   return (
-    <Rating
-      initialRating={initialValue}
-      start={0}
-      stop={10}
-      onChange={onChange}
-      emptySymbol={
-        dimension === TaskRatingDimension.BusinessValue ? (
-          <BusinessValueEmpty />
-        ) : (
-          <RequiredWorkEmpty />
-        )
-      }
-      fullSymbol={
-        dimension === TaskRatingDimension.BusinessValue ? (
-          <BusinessValueFilled />
-        ) : (
-          <RequiredWorkFilled />
-        )
-      }
-      readonly={readonly}
-    />
+    <div className={classes(css.ratingBar)}>
+      <MaterialRating
+        readOnly={readonly}
+        value={initialValue}
+        max={10}
+        onChange={(e, value) => {
+          if (onChange && value) onChange(value);
+        }}
+        onChangeActive={(e, value) => setHover(value)}
+        icon={
+          dimension === TaskRatingDimension.BusinessValue ? (
+            <BusinessValueEmpty />
+          ) : (
+            <RequiredWorkEmpty />
+          )
+        }
+        classes={{
+          icon: classes(css.icon),
+          iconFilled: classes(css.iconFilled),
+          iconEmpty: classes(css.iconEmpty),
+          iconActive: classes(css.iconActive),
+        }}
+      />
+      {!readonly && (
+        <div className={classes(css.rating)}>
+          {hover > 0
+            ? hover
+            : initialValue || <div className={classes(css.unrated)}>-</div>}
+        </div>
+      )}
+    </div>
   );
 };

--- a/frontend/src/components/TaskRatingWidget.module.scss
+++ b/frontend/src/components/TaskRatingWidget.module.scss
@@ -1,38 +1,15 @@
 @import '../shared.scss';
 
-.commentButton {
-  position: relative;
-  top: 0.15em;
-  cursor: pointer;
-  width: 1.5em;
-  height: 1.5em;
+.ratingWrapper {
+  margin-bottom: 16px;
 }
 
-.closeCommentButton {
-  position: absolute;
-  top: 0.5em;
-  right: 0.5em;
-  cursor: pointer;
-  user-select: none;
-  margin: 0px;
+.ratingBarWrapper {
+  margin-bottom: 8.75px;
+  display: flex;
+  align-items: stretch;
 }
 
 .commentBoxWrapper {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  bottom: 0;
-  margin-left: 2em;
-  margin-right: 2em;
-  z-index: 999;
-
-  textarea {
-    resize: none;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    height: 6em;
-  }
+  width: 450px;
 }

--- a/frontend/src/components/TaskRatingWidget.tsx
+++ b/frontend/src/components/TaskRatingWidget.tsx
@@ -1,10 +1,8 @@
 import { FC, useState } from 'react';
 import { Form } from 'react-bootstrap';
-import { ChatDots } from 'react-bootstrap-icons';
 import { useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 import classNames from 'classnames';
-import { ModalCloseButton } from './forms/SvgButton';
 import {
   TaskRatingDimension,
   RoleType,
@@ -55,11 +53,13 @@ export const TaskRatingWidget: FC<TaskRatingWidgetProps> = ({
     },
   );
 
-  const [commentBoxOpen, setCommentBoxOpen] = useState(false);
+  const [commentBoxOpen, setCommentBoxOpen] = useState(!!initialRating?.value);
 
   const ratingChanged = (value: number) => {
     setRating({ ...rating, value });
     if (onRatingChange) onRatingChange({ ...rating, value });
+    if (value) setCommentBoxOpen(true);
+    else setCommentBoxOpen(false);
   };
 
   const commentChanged = (comment: string) => {
@@ -74,46 +74,33 @@ export const TaskRatingWidget: FC<TaskRatingWidgetProps> = ({
 
   const renderRatingBars = () =>
     shouldShow && (
-      <Form.Group>
-        <div className="d-flex justify-content-around">
-          <TaskRatingBar
-            dimension={ratingDimension}
-            initialValue={rating.value}
-            onChange={ratingChanged}
-          />
-          <ChatDots
-            className={classes(css.commentButton)}
-            onClick={() => setCommentBoxOpen(true)}
-          />
-        </div>
-      </Form.Group>
+      <div className={classes(css.ratingBarWrapper)}>
+        <TaskRatingBar
+          dimension={ratingDimension}
+          initialValue={rating.value}
+          onChange={ratingChanged}
+        />
+      </div>
     );
 
-  const renderCommentBox = () => {
-    return (
+  const renderCommentBox = () =>
+    commentBoxOpen && (
       <Form.Group className={classes(css.commentBoxWrapper)}>
         <TextArea
-          required
           name="description"
           id="description"
           draggable="false"
-          placeholder={t('Comment your rating')}
+          placeholder={t('Add a comment')}
           value={rating.comment}
           onChange={(e) => commentChanged(e.currentTarget.value)}
         />
-        <div className={classes(css.closeCommentButton)}>
-          <ModalCloseButton
-            onClick={() => setCommentBoxOpen(false)}
-            aria-hidden="true"
-          />
-        </div>
       </Form.Group>
     );
-  };
 
   return (
-    <div className="position-relative">
-      {commentBoxOpen && renderCommentBox()} {renderRatingBars()}
+    <div className={classes(css.ratingWrapper)}>
+      {renderRatingBars()}
+      {renderCommentBox()}
     </div>
   );
 };

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -33,9 +33,7 @@ export const english = {
     Completed: 'Completed',
     'Not completed': 'Not completed',
     'Rate task': 'Rate task',
-    'Comment your rating': 'Comment your rating...',
-    'Please input a rating before submitting':
-      'Please input a rating before submitting',
+    'Add a comment': 'Add a comment...',
     Roadmap: 'Roadmap',
     'Roadmap View': 'Roadmap View',
     'Your projects': 'Your projects',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1573,6 +1573,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.60":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
@@ -2063,11 +2074,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
-"@types/lodash@^4.14.105":
-  version "4.14.171"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
-  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
-
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -2192,15 +2198,6 @@
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
   integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.0.40":
-  version "16.14.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.11.tgz#992a0cd4b66b9f27315042b5d96e976717368f04"
-  integrity sha512-Don0MtsZZ3fjwTJ2BsoqkyOy7e176KplEAKOpr/4XDdzinlyJBn9yfsKn5mcSgn4kh1B22+3tBnzBC1z63ybtQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10207,14 +10204,6 @@ react-overlays@^5.0.1:
     prop-types "^15.7.2"
     uncontrollable "^7.2.1"
     warning "^4.0.3"
-
-react-rating@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/react-rating/-/react-rating-2.0.5.tgz#2c9d7ebe5907db0361ba28b7c19f0394e6e4dd76"
-  integrity sha512-uldxgLCe5bzqGX7V+7/bPgQQj2Kok6eiMgTMxjKOhfhnQkFLDlc4TjMlp7gaJFAHWdbiOnqpiShI7z8as6oWtg==
-  dependencies:
-    "@types/lodash" "^4.14.105"
-    "@types/react" "^16.0.40"
 
 react-redux@^7.2.0, react-redux@^7.2.4:
   version "7.2.4"


### PR DESCRIPTION
Task rating is skipped on task creation if there are no customers to rate for

"Fixed" task rating modal styles according to figma
- Well, the styles look correct, but functionality feels messed up. Material UI's rating component allows the user to unselect the rating. Not sure if I would have used the component if I knew the feature could not be disabled...
  - <b>Example</b>: admin represents two customers -> they rate and submit the first customer's rating -> the rating modal can be opened again and the submitted rating can be unselected -> the submission will go through without error msgs, but the rating will not be patched
 
- Any ideas on the user flow? Should all ratings be given in one submission so the modal cannot be revisited? Or perhaps on submission, compare the initial and given ratings for differences instead of having a 'changed' attribute?