### PR TITLE
Move project overview page to higher level router

### DIFF
--- a/frontend/src/components/NavBar.module.scss
+++ b/frontend/src/components/NavBar.module.scss
@@ -16,6 +16,15 @@
   background-color: $COLOR_BLACK5;
 }
 
+.logo {
+  padding-top: 22px;
+  padding-left: 2px;
+  svg {
+    width: 60px;
+    height: 60px;
+  }
+}
+
 .navBarRightSide {
   margin-right: 16px;
   display: flex;

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -5,6 +5,7 @@ import PermIdentityIcon from '@material-ui/icons/PermIdentity';
 import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew';
 import classNames from 'classnames';
 import { ReactComponent as CornerPiece } from '../icons/corner_rounder.svg';
+import { ReactComponent as VisdomLogo } from '../icons/visdom_icon.svg';
 import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
@@ -36,6 +37,11 @@ export const NavBar = () => {
   return (
     <div className={classes(css.navBarDiv)}>
       <CornerPiece />
+      {pathname.startsWith(paths.overview) && (
+        <div className={classes(css.logo)}>
+          <VisdomLogo />
+        </div>
+      )}
       <div className={classes(css.navBarRightSide)}>
         <div className={classes(css.navBarText)}>
           <Trans i18nKey="Project" />

--- a/frontend/src/components/ProjectSummary.tsx
+++ b/frontend/src/components/ProjectSummary.tsx
@@ -82,8 +82,7 @@ const PeopleList: FC<{
 
 export const ProjectSummary: FC<{
   roadmap: Roadmap;
-  selected: boolean;
-}> = ({ roadmap, selected }) => {
+}> = ({ roadmap }) => {
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<
     (EventTarget & HTMLDivElement) | null
@@ -134,18 +133,12 @@ export const ProjectSummary: FC<{
       {!!roadmap.users?.length && (
         <PeopleList label="Team members" people={roadmap.users} />
       )}
-      {selected ? (
-        <button className="button-large" type="button" disabled>
-          <Trans i18nKey="Open" />
-        </button>
-      ) : (
-        <Link
-          className={classes(css.openButton)}
-          to={`${paths.roadmapHome}/${roadmap.id}${paths.roadmapRelative.dashboard}`}
-        >
-          <Trans i18nKey="Open" />
-        </Link>
-      )}
+      <Link
+        className={classes(css.openButton)}
+        to={`${paths.roadmapHome}/${roadmap.id}${paths.roadmapRelative.dashboard}`}
+      >
+        <Trans i18nKey="Open" />
+      </Link>
     </div>
   );
 };

--- a/frontend/src/components/RoadmapSelectorWidget.tsx
+++ b/frontend/src/components/RoadmapSelectorWidget.tsx
@@ -43,7 +43,7 @@ export const RoadmapSelectorWidget = () => {
         'chosenRoadmap',
         JSON.stringify({ id: chosenRoadmap.id }),
       );
-    }
+    } else setSelectedRoadmap('Select roadmap');
   }, [chosenRoadmap]);
 
   if (!roadmaps || roadmaps.length === 0) {

--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -108,14 +108,7 @@ export const RoadmapSidebar: FC = () => {
   return (
     <div className={classes('layout-column')}>
       <div className={classes(css.navButton, css.logo)}>
-        <Link
-          to={url + paths.roadmapRelative.overview}
-          className={classes(css.visdomLogo, {
-            [css.selected]: pathname.startsWith(
-              url + paths.roadmapRelative.overview,
-            ),
-          })}
-        >
+        <Link to={paths.overview} className={classes(css.visdomLogo)}>
           <VisdomLogo />
         </Link>
       </div>

--- a/frontend/src/pages/ProjectOverviewPage.module.scss
+++ b/frontend/src/pages/ProjectOverviewPage.module.scss
@@ -4,24 +4,28 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: auto;
-  margin-left: 15px;
+  padding-top: 100px;
+  height: 100%;
 
   h2 {
-    margin-left: 10px;
-    margin-bottom: 60px;
+    margin-left: 25px;
+    margin-bottom: 40px;
   }
 }
 
 .roadmapsContainer {
   display: flex;
   align-items: flex-start;
+  width: 100%;
+  height: 100%;
+  overflow-x: auto;
+  padding-left: 10px;
 }
 
 .addButtonContainer {
   display: flex;
   align-items: stretch;
   margin: 10px;
-  width: 360px;
-  height: 110px;
+  min-width: 360px;
+  min-height: 115px;
 }

--- a/frontend/src/pages/ProjectOverviewPage.tsx
+++ b/frontend/src/pages/ProjectOverviewPage.tsx
@@ -1,46 +1,40 @@
-import { MouseEvent, useState, useEffect } from 'react';
+import { MouseEvent, useEffect } from 'react';
 import classNames from 'classnames';
 import { Trans } from 'react-i18next';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { StoreDispatchType } from '../redux';
 import { roadmapsActions } from '../redux/roadmaps';
-import {
-  roadmapsSelector,
-  chosenRoadmapSelector,
-} from '../redux/roadmaps/selectors';
+import { roadmapsSelector } from '../redux/roadmaps/selectors';
 import { Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from '../components/modals/types';
 import { ProjectSummary } from '../components/ProjectSummary';
 import { AddButton } from '../components/forms/AddButton';
+import { requireLogin } from '../utils/requirelogin';
 import css from './ProjectOverviewPage.module.scss';
 
 const classes = classNames.bind(css);
 
-export const ProjectOverviewPage = () => {
+const ProjectOverviewComponent = () => {
   const dispatch = useDispatch<StoreDispatchType>();
   const roadmaps = useSelector<RootState, Roadmap[] | undefined>(
     roadmapsSelector,
     shallowEqual,
   );
-  const chosenRoadmap = useSelector<RootState, Roadmap | undefined>(
-    chosenRoadmapSelector,
-    shallowEqual,
-  );
-  const [selectedRoadmapId, setSelectedRoadmapId] = useState<
-    number | undefined
-  >(undefined);
 
   useEffect(() => {
     if (!roadmaps) dispatch(roadmapsActions.getRoadmaps());
   }, [dispatch, roadmaps]);
 
   useEffect(() => {
-    if (chosenRoadmap) {
-      setSelectedRoadmapId(chosenRoadmap.id);
-    }
-  }, [chosenRoadmap]);
+    if (localStorage.getItem('chosenRoadmap'))
+      localStorage.removeItem('chosenRoadmap');
+  }, []);
+
+  useEffect(() => {
+    dispatch(roadmapsActions.clearCurrentRoadmap());
+  }, [dispatch]);
 
   const addRoadmapClicked = (e: MouseEvent) => {
     e.preventDefault();
@@ -60,11 +54,7 @@ export const ProjectOverviewPage = () => {
       </h2>
       <div className={classes(css.roadmapsContainer)}>
         {roadmaps?.map((roadmap) => (
-          <ProjectSummary
-            roadmap={roadmap}
-            selected={selectedRoadmapId === roadmap.id}
-            key={roadmap.id}
-          />
+          <ProjectSummary roadmap={roadmap} key={roadmap.id} />
         ))}
         <div className={classes(css.addButtonContainer)}>
           <AddButton onClick={addRoadmapClicked}>
@@ -75,3 +65,5 @@ export const ProjectOverviewPage = () => {
     </div>
   );
 };
+
+export const ProjectOverviewPage = requireLogin(ProjectOverviewComponent);

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -45,6 +45,7 @@ import {
   PATCH_TASKRATING_FULFILLED,
   PATCH_TASK_FULFILLED,
   SELECT_CURRENT_ROADMAP,
+  CLEAR_CURRENT_ROADMAP,
   SET_PLANNER_CUSTOMER_WEIGHT,
   CLEAR_PLANNER_CUSTOMER_WEIGHTS,
   ADD_INTEGRATION_CONFIGURATION_FULFILLED,
@@ -66,6 +67,7 @@ export const roadmapsSlice = createSlice({
   initialState,
   reducers: {
     selectCurrentRoadmap: SELECT_CURRENT_ROADMAP,
+    clearCurrentRoadmap: CLEAR_CURRENT_ROADMAP,
     setPlannerCustomerWeight: SET_PLANNER_CUSTOMER_WEIGHT,
     clearPlannerCustomerWeights: CLEAR_PLANNER_CUSTOMER_WEIGHTS,
   },

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -231,6 +231,10 @@ export const SELECT_CURRENT_ROADMAP: CaseReducer<
   state.selectedRoadmapId = action.payload;
 };
 
+export const CLEAR_CURRENT_ROADMAP: CaseReducer<RoadmapsState> = (state) => {
+  state.selectedRoadmapId = undefined;
+};
+
 export const SET_PLANNER_CUSTOMER_WEIGHT: CaseReducer<
   RoadmapsState,
   PayloadAction<PlannerCustomerWeight>

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -9,6 +9,7 @@ import { LandingPage } from '../pages/LandingPage';
 import { LoginPage } from '../pages/LoginPage';
 import { LogoutPage } from '../pages/LogoutPage';
 import { RegisterPage } from '../pages/RegisterPage';
+import { ProjectOverviewPage } from '../pages/ProjectOverviewPage';
 import { NotFoundPage } from '../pages/NotFoundPage';
 import { UserInfoPage } from '../pages/UserInfoPage';
 import { paths } from './paths';
@@ -47,6 +48,11 @@ const routes = [
   {
     path: paths.userInfo,
     component: () => <NavLayout Content={UserInfoPage} />,
+    exact: false,
+  },
+  {
+    path: paths.overview,
+    component: () => <NavLayout Content={ProjectOverviewPage} />,
     exact: false,
   },
   {

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -9,7 +9,6 @@ import {
   useRouteMatch,
 } from 'react-router-dom';
 import { LoadingSpinner } from '../components/LoadingSpinner';
-import { ProjectOverviewPage } from '../pages/ProjectOverviewPage';
 import { DashboardPage } from '../pages/DashboardPage';
 import { ConfigurationPage } from '../pages/ConfigurationPage';
 import { TaskListPage } from '../pages/TaskListPage';
@@ -31,10 +30,6 @@ import { PlannerPageRouter } from './PlannerPageRouter';
 import '../shared.scss';
 
 const routes = [
-  {
-    path: paths.roadmapRelative.overview,
-    component: ProjectOverviewPage,
-  },
   {
     path: paths.roadmapRelative.dashboard,
     component: DashboardPage,

--- a/frontend/src/routers/paths.ts
+++ b/frontend/src/routers/paths.ts
@@ -5,12 +5,12 @@ export const paths = {
   logoutPage: '/logout',
   registerPage: '/register',
   getStarted: '/getstarted',
+  overview: '/overview',
   roadmapHome: '/roadmap',
   notFound: '/404',
   roadmapRouter: '/roadmap/:roadmapId([0-9]+)',
   roadmapRelative: {
     home: '/',
-    overview: '/overview',
     dashboard: '/dashboard',
     people: '/people',
     taskList: '/tasks',


### PR DESCRIPTION
- Changed route from 'roadmap/:selectedroadmapId/overview' to '/overview'.
- The sidebar will no longer show on the overview page.
- chosenRoadmap is removed from Localstorage when moving to the overview page, as no roadmap should be selected.