### PR TITLE
Fix developer task rating

### DIFF
--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -135,7 +135,10 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
       if (b.id === undefined && a.id !== undefined) return 1;
       return 0;
     })
-    .filter((rating) => rating.customer?.roadmapId === task.roadmapId);
+    .filter(
+      (rating) =>
+        !rating.customer || rating.customer.roadmapId === task.roadmapId,
+    );
 
   const [businessValueRatings, setBusinessValueRatings] = useState(ratings);
   const [businessRatingModified, setBusinessRatingModified] = useState(false);


### PR DESCRIPTION
Developers could not rate unrated tasks (rating modal was empty). Corrected filter predicate.
![image](https://user-images.githubusercontent.com/80758782/129536604-5ff5c68e-b503-4bed-a239-7ed2be0ba950.png)
