### PR TITLE
Task util refactor

### DIFF
--- a/frontend/src/components/CustomerListTable.tsx
+++ b/frontend/src/components/CustomerListTable.tsx
@@ -8,7 +8,6 @@ import { roadmapsActions } from '../redux/roadmaps';
 import {
   allCustomersSelector,
   plannerCustomerWeightsSelector,
-  allTasksSelector,
   chosenRoadmapSelector,
 } from '../redux/roadmaps/selectors';
 import {
@@ -48,11 +47,13 @@ export const CustomerList: FC<{
     chosenRoadmapSelector,
     shallowEqual,
   );
-  const tasks = useSelector(allTasksSelector(), shallowEqual);
   const dispatch = useDispatch<StoreDispatchType>();
 
   const [sort, sorting] = useSorting(
-    useMemo(() => customerSort(tasks, plannedWeights), [tasks, plannedWeights]),
+    useMemo(() => customerSort(currentRoadmap, plannedWeights), [
+      currentRoadmap,
+      plannedWeights,
+    ]),
   );
 
   useEffect(() => {

--- a/frontend/src/components/PlannerChart.tsx
+++ b/frontend/src/components/PlannerChart.tsx
@@ -15,10 +15,8 @@ import classNames from 'classnames';
 import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
 import { Roadmap, Task } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
-import {
-  calcWeightedTaskPriority,
-  valueAndWorkSummary,
-} from '../utils/TaskUtils';
+import { weightedTaskPriority, valueAndWorkSummary } from '../utils/TaskUtils';
+import { sort, sortKeyNumeric } from '../utils/SortUtils';
 import css from './PlannerChart.module.scss';
 
 const classes = classNames.bind(css);
@@ -47,10 +45,8 @@ export const PlannerChart: FC<{
 
     graphTaskLists.unshift({
       name: DataKeys.OptimalRoadmap,
-      tasks: [...currentRoadmap.tasks].sort(
-        (a, b) =>
-          calcWeightedTaskPriority(b, currentRoadmap) -
-          calcWeightedTaskPriority(a, currentRoadmap),
+      tasks: sort(sortKeyNumeric(weightedTaskPriority(currentRoadmap)))(
+        currentRoadmap.tasks,
       ),
     });
   }

--- a/frontend/src/components/RoadmapCompletionMeter.tsx
+++ b/frontend/src/components/RoadmapCompletionMeter.tsx
@@ -5,6 +5,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
 import { Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
+import { partition } from '../utils/array';
 import css from './RoadmapCompletionMeter.module.scss';
 
 const classes = classNames.bind(css);
@@ -15,13 +16,14 @@ export const RoadmapCompletionMeter = () => {
     shallowEqual,
   );
 
+  const [completed, uncompleted] = partition(
+    currentRoadmap?.tasks ?? [],
+    (t) => t.completed,
+  ).map((a) => a.length);
+
   const getCompletionPercent = () => {
-    const totalTasks = currentRoadmap!.tasks.length;
-    if (totalTasks === 0) return 0;
-    const completedTasks = currentRoadmap!.tasks.filter(
-      (task) => task.completed,
-    ).length;
-    return Math.round((completedTasks / totalTasks) * 100);
+    const total = completed + uncompleted;
+    return total === 0 ? 0 : Math.round((completed / total) * 100);
   };
 
   const options = {
@@ -78,12 +80,8 @@ export const RoadmapCompletionMeter = () => {
         series={[getCompletionPercent()]}
         width="250"
       />
-      <span className={classes(css.completedtasks)}>
-        {currentRoadmap!.tasks.filter((task) => task.completed).length}
-      </span>
-      <span className={classes(css.notcompletedtasks)}>
-        {currentRoadmap!.tasks.filter((task) => !task.completed).length}
-      </span>
+      <span className={classes(css.completedtasks)}>{completed}</span>
+      <span className={classes(css.notcompletedtasks)}>{uncompleted}</span>
     </div>
   );
 };

--- a/frontend/src/components/SortingArrow.tsx
+++ b/frontend/src/components/SortingArrow.tsx
@@ -1,0 +1,6 @@
+import { FC } from 'react';
+import { ArrowDownCircle, ArrowUpCircle } from 'react-bootstrap-icons';
+import { SortingOrders } from '../utils/SortUtils';
+
+export const SortingArrow: FC<{ order: SortingOrders }> = ({ order }) =>
+  order === SortingOrders.ASCENDING ? <ArrowUpCircle /> : <ArrowDownCircle />;

--- a/frontend/src/components/TableCustomerRow.tsx
+++ b/frontend/src/components/TableCustomerRow.tsx
@@ -44,13 +44,7 @@ export const TableCustomerRow: FC<TableRowProps> = ({ customer }) => {
 
   useEffect(() => {
     if (currentRoadmap?.tasks)
-      setUnratedAmount(
-        unratedTasksAmount(
-          customer,
-          currentRoadmap.tasks,
-          currentRoadmap.customers,
-        ),
-      );
+      setUnratedAmount(unratedTasksAmount(customer, currentRoadmap));
   }, [currentRoadmap, customer]);
 
   const deleteUserClicked = (e: MouseEvent) => {

--- a/frontend/src/components/TableTeamMemberRow.tsx
+++ b/frontend/src/components/TableTeamMemberRow.tsx
@@ -39,13 +39,7 @@ export const TableTeamMemberRow: FC<TableRowProps> = ({ member }) => {
 
   useEffect(() => {
     if (currentRoadmap?.tasks)
-      setUnratedAmount(
-        unratedTasksAmount(
-          member,
-          currentRoadmap.tasks,
-          currentRoadmap.customers,
-        ),
-      );
+      setUnratedAmount(unratedTasksAmount(member, currentRoadmap));
   }, [currentRoadmap, member]);
 
   const deleteUserClicked = (e: MouseEvent) => {

--- a/frontend/src/components/TaskTable.tsx
+++ b/frontend/src/components/TaskTable.tsx
@@ -14,7 +14,7 @@ import { InfoTooltip } from './InfoTooltip';
 import { SortingArrow } from './SortingArrow';
 import { useSorting } from '../utils/SortUtils';
 import {
-  filterTasks,
+  taskFilter,
   FilterTypes,
   SortingTypes,
   taskSort,
@@ -64,11 +64,10 @@ export const taskTable: (def: TaskTableDef) => FC<TaskTableProps> = ({
 
   const [scrollBarWidth, setScrollBarWidth] = useState(0);
 
+  const predicate = taskFilter(searchFilter, userInfo);
+
   // Filter, search, sort tasks
-  const filtered =
-    searchFilter === undefined
-      ? tasks
-      : filterTasks(tasks, searchFilter, userInfo?.id);
+  const filtered = predicate ? tasks.filter(predicate) : tasks;
 
   const searched = !searchString
     ? filtered

--- a/frontend/src/components/TeamMemberListTable.tsx
+++ b/frontend/src/components/TeamMemberListTable.tsx
@@ -8,7 +8,6 @@ import { roadmapsActions } from '../redux/roadmaps';
 import {
   roadmapUsersSelector,
   chosenRoadmapSelector,
-  allTasksSelector,
 } from '../redux/roadmaps/selectors';
 import { RoadmapUser, Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
@@ -40,14 +39,10 @@ export const TeamMemberList: FC<{
     chosenRoadmapSelector,
     shallowEqual,
   );
-  const tasks = useSelector(allTasksSelector(), shallowEqual);
   const dispatch = useDispatch<StoreDispatchType>();
 
   const [sort, sorting] = useSorting(
-    useMemo(() => userSort(tasks, currentRoadmap?.customers), [
-      tasks,
-      currentRoadmap,
-    ]),
+    useMemo(() => userSort(currentRoadmap), [currentRoadmap]),
   );
 
   useEffect(() => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,7 +17,7 @@ import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
 import { RoleType, Permission } from '../../../shared/types/customTypes';
-import { splitTasksOnRated } from '../utils/TaskUtils';
+import { isUnrated } from '../utils/TaskUtils';
 import { getType, hasPermission } from '../utils/UserUtils';
 import css from './DashboardPage.module.scss';
 
@@ -88,12 +88,11 @@ export const DashboardPage = () => {
   }, [dispatch, roadmapsVersions, currentRoadmap]);
 
   useEffect(() => {
-    const { unrated } = splitTasksOnRated(
-      currentRoadmap?.tasks ?? [],
-      userInfo,
-      currentRoadmap,
-    );
-    setUnratedTasks(unrated);
+    if (userInfo && currentRoadmap) {
+      setUnratedTasks(
+        currentRoadmap.tasks.filter(isUnrated(userInfo, currentRoadmap)),
+      );
+    }
   }, [currentRoadmap, userInfo]);
 
   return (

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -32,11 +32,8 @@ import {
   Version,
 } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
-import {
-  calcWeightedTaskPriority,
-  dragDropBetweenLists,
-  reorderList,
-} from '../utils/TaskUtils';
+import { calcWeightedTaskPriority } from '../utils/TaskUtils';
+import { move } from '../utils/array';
 import css from './MilestonesEditor.module.scss';
 
 const classes = classNames.bind(css);
@@ -188,12 +185,8 @@ export const MilestonesEditor = () => {
     const { source, destination } = result;
     const copyLists = copyVersionLists(versionLists);
 
-    // Reordering inside one list
-    copyLists[source.droppableId] = reorderList(
-      copyLists[source.droppableId],
-      source.index,
-      destination!.index,
-    );
+    const list = copyLists[source.droppableId];
+    move().from(list, source.index).to(list, destination!.index);
 
     setVersionLists(copyLists);
     if (destination?.droppableId === ROADMAP_LIST_ID) return Promise.resolve();
@@ -214,16 +207,9 @@ export const MilestonesEditor = () => {
     const { source, destination } = result;
     const copyLists = copyVersionLists(versionLists);
 
-    // Moving from one list to another
-    Object.assign(
-      copyLists,
-      dragDropBetweenLists(
-        copyLists[source.droppableId],
-        copyLists[destination!.droppableId],
-        source,
-        destination!,
-      ),
-    );
+    move()
+      .from(copyLists[source.droppableId], source.index)
+      .to(copyLists[destination!.droppableId], destination!.index);
     setVersionLists(copyLists);
 
     setDisableUpdates(true);

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -120,7 +120,7 @@ export const MilestonesEditor = () => {
     );
   };
 
-  const deleteVersionClicked = (e: MouseEvent, id: number) => {
+  const deleteVersionClicked = (id: number) => (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     dispatch(
@@ -131,7 +131,7 @@ export const MilestonesEditor = () => {
     );
   };
 
-  const editVersionClicked = (e: MouseEvent, id: number, name: string) => {
+  const editVersionClicked = (id: number, name: string) => (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     dispatch(
@@ -332,16 +332,14 @@ export const MilestonesEditor = () => {
                     <div className={classes(css.milestoneFooter)}>
                       <DeleteButton
                         type="filled"
-                        onClick={(e) => deleteVersionClicked(e, version.id)}
+                        onClick={deleteVersionClicked(version.id)}
                         href={modalLink(ModalTypes.DELETE_VERSION_MODAL, {
                           id: version.id,
                           roadmapId: currentRoadmap.id,
                         })}
                       />
                       <SettingsButton
-                        onClick={(e) =>
-                          editVersionClicked(e, version.id, version.name)
-                        }
+                        onClick={editVersionClicked(version.id, version.name)}
                         href={modalLink(ModalTypes.EDIT_VERSION_MODAL, {
                           id: version.id,
                           name: version.name,

--- a/frontend/src/pages/TaskListPage.tsx
+++ b/frontend/src/pages/TaskListPage.tsx
@@ -14,7 +14,8 @@ import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
 import { RoleType } from '../../../shared/types/customTypes';
-import { FilterTypes, splitTasksOnRated } from '../utils/TaskUtils';
+import { FilterTypes, isUnrated } from '../utils/TaskUtils';
+import { partition } from '../utils/array';
 import { titleCase } from '../utils/string';
 import css from './TaskListPage.module.scss';
 import {
@@ -31,8 +32,7 @@ export const TaskListPage = () => {
   const [checked, setChecked] = useState(true);
   const [searchString, setSearchString] = useState('');
   const [searchFilter, setSearchFilter] = useState(FilterTypes.SHOW_ALL);
-  const [rated, setRated] = useState<Task[]>([]);
-  const [unrated, setUnrated] = useState<Task[]>([]);
+  const [[unrated, rated], setTasks] = useState<[Task[], Task[]]>([[], []]);
 
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,
@@ -46,9 +46,8 @@ export const TaskListPage = () => {
   const dispatch = useDispatch<StoreDispatchType>();
 
   useEffect(() => {
-    const split = splitTasksOnRated(tasks, userInfo, currentRoadmap);
-    setUnrated(split.unrated);
-    setRated(split.rated);
+    if (userInfo && currentRoadmap)
+      setTasks(partition(tasks, isUnrated(userInfo, currentRoadmap)));
   }, [currentRoadmap, tasks, userInfo]);
 
   const onSearchChange = (value: string) => {

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -462,11 +462,7 @@ export const addTaskToVersion = createAsyncThunk<
 
     payload.tasks.splice(request.index, 0, request.task.id!);
     try {
-      const res = await thunkAPI.dispatch(patchVersion(payload));
-      if (patchVersion.rejected.match(res)) {
-        return thunkAPI.rejectWithValue(res.payload!);
-      }
-      return res.payload;
+      return await thunkAPI.dispatch(patchVersion(payload)).unwrap();
     } catch (err) {
       return thunkAPI.rejectWithValue(err);
     }
@@ -491,11 +487,7 @@ export const removeTaskFromVersion = createAsyncThunk<
       (taskId) => taskId !== request.task.id,
     );
     try {
-      const res = await thunkAPI.dispatch(patchVersion(payload));
-      if (patchVersion.rejected.match(res)) {
-        return thunkAPI.rejectWithValue(res.payload!);
-      }
-      return res.payload;
+      return await thunkAPI.dispatch(patchVersion(payload)).unwrap();
     } catch (err) {
       return thunkAPI.rejectWithValue(err);
     }

--- a/frontend/src/utils/SortCustomerUtils.ts
+++ b/frontend/src/utils/SortCustomerUtils.ts
@@ -1,4 +1,8 @@
-import { Customer, PlannerCustomerWeight, Task } from '../redux/roadmaps/types';
+import {
+  Customer,
+  PlannerCustomerWeight,
+  Roadmap,
+} from '../redux/roadmaps/types';
 import { unratedTasksAmount } from './TaskUtils';
 import { customerWeight } from './CustomerUtils';
 
@@ -13,7 +17,7 @@ export enum CustomerSortingTypes {
 }
 
 export const customerSort = (
-  tasks: Task[],
+  roadmap?: Roadmap,
   plannedWeights?: PlannerCustomerWeight[],
 ) => (type: CustomerSortingTypes | undefined): Sort<Customer> => {
   switch (type) {
@@ -28,7 +32,10 @@ export const customerSort = (
     case CustomerSortingTypes.SORT_COLOR:
       return sortKeyLocale('color');
     case CustomerSortingTypes.SORT_UNRATED:
-      return sortKeyNumeric((customer) => unratedTasksAmount(customer, tasks));
+      return (
+        roadmap &&
+        sortKeyNumeric((customer) => unratedTasksAmount(customer, roadmap))
+      );
     default:
       break;
   }

--- a/frontend/src/utils/SortCustomerUtils.ts
+++ b/frontend/src/utils/SortCustomerUtils.ts
@@ -2,18 +2,9 @@ import { Customer, PlannerCustomerWeight, Task } from '../redux/roadmaps/types';
 import { unratedTasksAmount } from './TaskUtils';
 import { customerWeight } from './CustomerUtils';
 
-import {
-  SortingOrders,
-  Sort,
-  sort,
-  sortKeyLocale,
-  sortKeyNumeric,
-} from './SortUtils';
-
-export { SortingOrders } from './SortUtils';
+import { Sort, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
 export enum CustomerSortingTypes {
-  NO_SORT,
   SORT_NAME,
   SORT_EMAIL,
   SORT_VALUE,
@@ -21,12 +12,11 @@ export enum CustomerSortingTypes {
   SORT_UNRATED,
 }
 
-const customerCompare = (
-  sortingType: CustomerSortingTypes,
+export const customerSort = (
   tasks: Task[],
   plannedWeights?: PlannerCustomerWeight[],
-): Sort<Customer, any> | undefined => {
-  switch (sortingType) {
+) => (type: CustomerSortingTypes | undefined): Sort<Customer> => {
+  switch (type) {
     case CustomerSortingTypes.SORT_NAME:
       return sortKeyLocale('name');
     case CustomerSortingTypes.SORT_EMAIL:
@@ -40,15 +30,6 @@ const customerCompare = (
     case CustomerSortingTypes.SORT_UNRATED:
       return sortKeyNumeric((customer) => unratedTasksAmount(customer, tasks));
     default:
-      // SortingTypes.NO_SORT
       break;
   }
 };
-
-export const sortCustomers = (
-  customers: Customer[],
-  type: CustomerSortingTypes,
-  order: SortingOrders,
-  tasks: Task[],
-  plannedWeights?: PlannerCustomerWeight[],
-) => sort(customerCompare(type, tasks, plannedWeights), order)(customers);

--- a/frontend/src/utils/SortCustomerUtils.ts
+++ b/frontend/src/utils/SortCustomerUtils.ts
@@ -6,7 +6,7 @@ import {
 import { unratedTasksAmount } from './TaskUtils';
 import { customerWeight } from './CustomerUtils';
 
-import { Sort, sortKeyLocale, sortKeyNumeric } from './SortUtils';
+import { SortBy, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
 export enum CustomerSortingTypes {
   SORT_NAME,
@@ -19,7 +19,7 @@ export enum CustomerSortingTypes {
 export const customerSort = (
   roadmap?: Roadmap,
   plannedWeights?: PlannerCustomerWeight[],
-) => (type: CustomerSortingTypes | undefined): Sort<Customer> => {
+) => (type: CustomerSortingTypes | undefined): SortBy<Customer> => {
   switch (type) {
     case CustomerSortingTypes.SORT_NAME:
       return sortKeyLocale('name');

--- a/frontend/src/utils/SortRoadmapUserUtils.ts
+++ b/frontend/src/utils/SortRoadmapUserUtils.ts
@@ -1,50 +1,30 @@
 import { RoadmapUser, Task, Customer } from '../redux/roadmaps/types';
 import { RoleType } from '../../../shared/types/customTypes';
 import { unratedTasksAmount } from './TaskUtils';
-import {
-  SortingOrders,
-  sort,
-  Sort,
-  sortKeyLocale,
-  sortKeyNumeric,
-} from './SortUtils';
-
-export { SortingOrders } from './SortUtils';
+import { Sort, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
 export enum UserSortingTypes {
-  NO_SORT,
   SORT_NAME,
   SORT_EMAIL,
   SORT_ROLE,
   SORT_UNRATED,
 }
 
-const userCompare = (
-  sortingType: UserSortingTypes,
-  tasks: Task[],
-  customers?: Customer[],
-): Sort<RoadmapUser, any> | undefined => {
-  switch (sortingType) {
+export const userSort = (tasks: Task[], customers?: Customer[]) => (
+  type: UserSortingTypes | undefined,
+): Sort<RoadmapUser> => {
+  switch (type) {
     case UserSortingTypes.SORT_NAME:
       return sortKeyLocale('username');
     case UserSortingTypes.SORT_EMAIL:
       return sortKeyLocale('email');
     case UserSortingTypes.SORT_ROLE:
-      return sortKeyLocale(({ type }) => RoleType[type]);
+      return sortKeyLocale((user) => RoleType[user.type]);
     case UserSortingTypes.SORT_UNRATED:
       return sortKeyNumeric((user) =>
         unratedTasksAmount(user, tasks, customers),
       );
     default:
-      // SortingTypes.NO_SORT
       break;
   }
 };
-
-export const sortRoadmapUsers = (
-  users: RoadmapUser[],
-  type: UserSortingTypes,
-  order: SortingOrders,
-  tasks: Task[],
-  customers?: Customer[],
-) => sort(userCompare(type, tasks, customers), order)(users);

--- a/frontend/src/utils/SortRoadmapUserUtils.ts
+++ b/frontend/src/utils/SortRoadmapUserUtils.ts
@@ -1,7 +1,7 @@
 import { RoadmapUser, Roadmap } from '../redux/roadmaps/types';
 import { RoleType } from '../../../shared/types/customTypes';
 import { unratedTasksAmount } from './TaskUtils';
-import { Sort, sortKeyLocale, sortKeyNumeric } from './SortUtils';
+import { SortBy, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
 export enum UserSortingTypes {
   SORT_NAME,
@@ -12,7 +12,7 @@ export enum UserSortingTypes {
 
 export const userSort = (roadmap?: Roadmap) => (
   type: UserSortingTypes | undefined,
-): Sort<RoadmapUser> => {
+): SortBy<RoadmapUser> => {
   switch (type) {
     case UserSortingTypes.SORT_NAME:
       return sortKeyLocale('username');

--- a/frontend/src/utils/SortRoadmapUserUtils.ts
+++ b/frontend/src/utils/SortRoadmapUserUtils.ts
@@ -1,4 +1,4 @@
-import { RoadmapUser, Task, Customer } from '../redux/roadmaps/types';
+import { RoadmapUser, Roadmap } from '../redux/roadmaps/types';
 import { RoleType } from '../../../shared/types/customTypes';
 import { unratedTasksAmount } from './TaskUtils';
 import { Sort, sortKeyLocale, sortKeyNumeric } from './SortUtils';
@@ -10,7 +10,7 @@ export enum UserSortingTypes {
   SORT_UNRATED,
 }
 
-export const userSort = (tasks: Task[], customers?: Customer[]) => (
+export const userSort = (roadmap?: Roadmap) => (
   type: UserSortingTypes | undefined,
 ): Sort<RoadmapUser> => {
   switch (type) {
@@ -21,8 +21,8 @@ export const userSort = (tasks: Task[], customers?: Customer[]) => (
     case UserSortingTypes.SORT_ROLE:
       return sortKeyLocale((user) => RoleType[user.type]);
     case UserSortingTypes.SORT_UNRATED:
-      return sortKeyNumeric((user) =>
-        unratedTasksAmount(user, tasks, customers),
+      return (
+        roadmap && sortKeyNumeric((user) => unratedTasksAmount(user, roadmap))
       );
     default:
       break;

--- a/frontend/src/utils/SortUtils.ts
+++ b/frontend/src/utils/SortUtils.ts
@@ -21,7 +21,7 @@ type Key<T, K> = PropertyKey<T, K> | ((value: T) => K);
 
 type Comparison<T> = (a: T, b: T) => number;
 
-export type Sort<T, K = any> =
+export type SortBy<T, K = any> =
   | undefined
   | {
       key: Key<T, K>;
@@ -32,7 +32,7 @@ export type Sort<T, K = any> =
 const sortKeyCompare = <T, K>(
   key: Key<T, K>,
   compare: Comparison<K>,
-): Sort<T, K> => ({ key, compare });
+): SortBy<T, K> => ({ key, compare });
 
 export const sortKeyNumeric = <T>(key: Key<T, number>) =>
   sortKeyCompare(key, (a, b) => a - b);
@@ -41,7 +41,7 @@ export const sortKeyLocale = <T>(key: Key<T, string>) =>
   sortKeyCompare(key, (a, b) => a.localeCompare(b));
 
 export const sort = <T, K>(
-  by: Sort<T, K>,
+  by: SortBy<T, K>,
   order: SortingOrders = SortingOrders.ASCENDING,
 ) => {
   // no sorting
@@ -68,7 +68,7 @@ export const sort = <T, K>(
 };
 
 export const useSorting = <SortingType, ItemType>(
-  getSort: (t: SortingType | undefined) => Sort<ItemType>,
+  getSort: (t: SortingType | undefined) => SortBy<ItemType>,
 ) => {
   const [type, setType] = useState<SortingType | undefined>();
   const [order, setOrder] = useState(SortingOrders.ASCENDING);

--- a/frontend/src/utils/SortUtils.ts
+++ b/frontend/src/utils/SortUtils.ts
@@ -40,7 +40,10 @@ export const sortKeyNumeric = <T>(key: Key<T, number>) =>
 export const sortKeyLocale = <T>(key: Key<T, string>) =>
   sortKeyCompare(key, (a, b) => a.localeCompare(b));
 
-const sort = <T, K>(by: Sort<T, K>, order: SortingOrders) => {
+export const sort = <T, K>(
+  by: Sort<T, K>,
+  order: SortingOrders = SortingOrders.ASCENDING,
+) => {
   // no sorting
   if (!by) return (list: T[]) => list;
 

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -11,7 +11,7 @@ import {
   RoleType,
   TaskRatingDimension,
 } from '../../../shared/types/customTypes';
-import { Sort, sortKeyNumeric, sortKeyLocale } from './SortUtils';
+import { SortBy, sortKeyNumeric, sortKeyLocale } from './SortUtils';
 import { getType, isUserInfo } from './UserUtils';
 
 export enum FilterTypes {
@@ -143,7 +143,7 @@ export const taskFilter = (
   }
 };
 
-export const taskSort = (type: SortingTypes | undefined): Sort<Task> => {
+export const taskSort = (type: SortingTypes | undefined): SortBy<Task> => {
   switch (type) {
     case SortingTypes.SORT_CREATEDAT:
       return sortKeyNumeric((t) => new Date(t.createdAt).getTime());
@@ -243,12 +243,12 @@ export const awaitsUserRatings = (
   const roadmapId = typeof roadmap === 'number' ? roadmap : roadmap.id;
   const type = getType(user.roles, roadmapId);
   if (type === RoleType.Admin || type === RoleType.Business) {
-    const reps = user.representativeFor?.filter(
+    const customers = user.representativeFor?.filter(
       (customer) => customer.roadmapId === roadmapId,
     );
     return (task: Task) =>
       task.roadmapId === roadmapId &&
-      !reps?.every((customer) => ratedByCustomer(customer, user)(task));
+      !customers?.every((customer) => ratedByCustomer(customer, user)(task));
   }
   return not(ratedByUser(user));
 };
@@ -280,11 +280,11 @@ export const isUnrated = (
   }
 
   if (user.type === RoleType.Admin || user.type === RoleType.Business) {
-    const represented = roadmap.customers?.filter((customer) =>
+    const customers = roadmap.customers?.filter((customer) =>
       customer.representatives?.some((rep) => rep.id === user.id),
     );
     return (task) =>
-      !!represented?.some((customer) => !ratedByCustomer(customer, user)(task));
+      !!customers?.some((customer) => !ratedByCustomer(customer, user)(task));
   }
   return not(ratedByUser(user));
 };

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -104,7 +104,7 @@ const calcTaskPriority = (task: Task) => {
   return value.avg / work.avg;
 };
 
-const not = <T>(f: (t: T) => boolean) => (t: T) => !f(t);
+export const not = <T>(f: (t: T) => boolean) => (t: T) => !f(t);
 
 export const ratedByUser = (user: RoadmapUser | UserInfo) => (task: Task) =>
   task.ratings.some((rating) => rating.createdByUser === user.id);
@@ -225,7 +225,7 @@ export const totalWeightedValueAndWork = (tasks: Task[], roadmap: Roadmap) => {
   return { value: totalValues.sum, totalValue: totalValues.total, work };
 };
 
-export const calcWeightedTaskPriority = (task: Task, roadmap: Roadmap) => {
+export const weightedTaskPriority = (roadmap: Roadmap) => (task: Task) => {
   const weightedValue = taskWeightedValueSummary(task, roadmap).avg;
   if (!weightedValue) return -2;
 
@@ -253,7 +253,7 @@ export const awaitsUserRatings = (
   return not(ratedByUser(user));
 };
 
-const isUnratedProductOwnerTask = ({ users = [], customers = [] }: Roadmap) => {
+export const hasMissingRatings = ({ users = [], customers = [] }: Roadmap) => {
   const devs = users.filter((user) => user.type === RoleType.Developer);
   const reps = customers.map((customer) => customer.representatives ?? []);
   const shouldHaveRated = devs.concat(...reps);
@@ -275,7 +275,7 @@ export const isUnrated = (
 
   if (isUserInfo(user)) {
     return getType(user.roles, roadmap.id) === RoleType.Admin
-      ? isUnratedProductOwnerTask(roadmap)
+      ? hasMissingRatings(roadmap)
       : awaitsUserRatings(user, roadmap);
   }
 

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -1,4 +1,3 @@
-import { DraggableLocation } from 'react-beautiful-dnd';
 import {
   Customer,
   Roadmap,
@@ -167,38 +166,6 @@ export const taskSort = (type: SortingTypes | undefined): Sort<Task> => {
     default:
       break;
   }
-};
-
-// Function to help with reordering item in list
-export const reorderList = (
-  list: Task[],
-  startIndex: number,
-  endIndex: number,
-) => {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
-
-  return result;
-};
-
-// Function to help move items between lists
-export const dragDropBetweenLists = (
-  source: Task[],
-  destination: Task[],
-  droppableSource: DraggableLocation,
-  droppableDestination: DraggableLocation,
-) => {
-  const sourceClone = Array.from(source);
-  const destClone = Array.from(destination);
-  const [removed] = sourceClone.splice(droppableSource.index, 1);
-
-  destClone.splice(droppableDestination.index, 0, removed);
-
-  return {
-    [droppableSource.droppableId]: sourceClone,
-    [droppableDestination.droppableId]: destClone,
-  };
 };
 
 const ratingValueAndCreator = (roadmap: Roadmap, notWeighted?: boolean) => (

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -14,10 +14,10 @@ import {
 } from '../../../shared/types/customTypes';
 import {
   SortingOrders,
-  sorted,
+  sort,
+  Sort,
   sortKeyNumeric,
   sortKeyLocale,
-  SortComparison,
 } from './SortUtils';
 import { getType, isUserInfo } from './UserUtils';
 
@@ -105,7 +105,7 @@ export const averageValueAndWork = (tasks: Task[]) => {
   };
 };
 
-export const calcTaskPriority = (task: Task) => {
+const calcTaskPriority = (task: Task) => {
   const ratings = ratingsSummaryByDimension(task);
   const value = ratings.get(TaskRatingDimension.BusinessValue);
   const work = ratings.get(TaskRatingDimension.RequiredWork);
@@ -114,7 +114,7 @@ export const calcTaskPriority = (task: Task) => {
   return value.avg / work.avg;
 };
 
-export const filterTasksRatedByUser = (userId: number = -1, rated: boolean) => {
+const filterTasksRatedByUser = (userId: number = -1, rated: boolean) => {
   return (task: Task) => {
     if (
       task.ratings.some((taskrating) => taskrating.createdByUser === userId)
@@ -125,7 +125,7 @@ export const filterTasksRatedByUser = (userId: number = -1, rated: boolean) => {
   };
 };
 
-export const filterTasksByCompletion = (completion: boolean) => {
+const filterTasksByCompletion = (completion: boolean) => {
   return (task: Task) => task.completed === completion;
 };
 
@@ -156,14 +156,14 @@ export const filterTasks = (
 
 const taskCompare = (
   sortingType: SortingTypes,
-): SortComparison<Task> | undefined => {
+): Sort<Task, any> | undefined => {
   switch (sortingType) {
     case SortingTypes.SORT_CREATEDAT:
       return sortKeyNumeric((t) => new Date(t.createdAt).getTime());
     case SortingTypes.SORT_NAME:
-      return sortKeyLocale((t) => t.name);
+      return sortKeyLocale('name');
     case SortingTypes.SORT_DESC:
-      return sortKeyLocale((t) => t.description);
+      return sortKeyLocale('description');
     case SortingTypes.SORT_STATUS:
       return sortKeyNumeric((t) => +t.completed);
     case SortingTypes.SORT_RATINGS:
@@ -186,7 +186,7 @@ export const sortTasks = (
   taskList: Task[],
   sortingType: SortingTypes,
   sortingOrder: SortingOrders,
-) => sorted(taskList, taskCompare(sortingType), sortingOrder);
+) => sort(taskCompare(sortingType), sortingOrder)(taskList);
 
 // Function to help with reordering item in list
 export const reorderList = (
@@ -288,22 +288,19 @@ export const calcWeightedTaskPriority = (task: Task, roadmap: Roadmap) => {
   return weightedValue / avgWorkRating;
 };
 
-export const isRatedByUser = (user: RoadmapUser | UserInfo) => (
-  rating: Taskrating,
-) => rating.createdByUser === user.id;
+const isRatedByUser = (user: RoadmapUser | UserInfo) => (rating: Taskrating) =>
+  rating.createdByUser === user.id;
 
-export const isRatedByCustomer = (
-  customer: Customer,
-  rep: RoadmapUser | UserInfo,
-) => (rating: Taskrating) =>
-  rating.forCustomer === customer.id && rating.createdByUser === rep.id;
+const isRatedByCustomer = (customer: Customer, rep: RoadmapUser | UserInfo) => (
+  rating: Taskrating,
+) => rating.forCustomer === customer.id && rating.createdByUser === rep.id;
 
 /*
   For Customers consider missing representative ratings
   For Admin and Business -users consider missing represented ratings
   For others consider their own missing ratings
 */
-export const isUnrated = (
+const isUnrated = (
   user: RoadmapUser | Customer | UserInfo,
   customers?: Customer[],
 ) => (task: Task) => {
@@ -330,7 +327,7 @@ export const isUnrated = (
   return !task.ratings.find(isRatedByUser(user));
 };
 
-export const unratedTasks = (
+const unratedTasks = (
   user: RoadmapUser | Customer | UserInfo,
   tasks: Task[],
   customers?: Customer[],

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -12,16 +12,8 @@ import {
   RoleType,
   TaskRatingDimension,
 } from '../../../shared/types/customTypes';
-import {
-  SortingOrders,
-  sort,
-  Sort,
-  sortKeyNumeric,
-  sortKeyLocale,
-} from './SortUtils';
+import { Sort, sortKeyNumeric, sortKeyLocale } from './SortUtils';
 import { getType, isUserInfo } from './UserUtils';
-
-export { SortingOrders } from './SortUtils';
 
 export enum FilterTypes {
   SHOW_ALL,
@@ -32,7 +24,6 @@ export enum FilterTypes {
 }
 
 export enum SortingTypes {
-  NO_SORT,
   SORT_NAME,
   SORT_STATUS,
   SORT_DESC,
@@ -154,10 +145,8 @@ export const filterTasks = (
   return taskList.filter(filterFunc);
 };
 
-const taskCompare = (
-  sortingType: SortingTypes,
-): Sort<Task, any> | undefined => {
-  switch (sortingType) {
+export const taskSort = (type: SortingTypes | undefined): Sort<Task> => {
+  switch (type) {
     case SortingTypes.SORT_CREATEDAT:
       return sortKeyNumeric((t) => new Date(t.createdAt).getTime());
     case SortingTypes.SORT_NAME:
@@ -177,16 +166,9 @@ const taskCompare = (
     case SortingTypes.SORT_TOTAL_WORK:
       return sortKeyNumeric((t) => valueAndWorkSummary(t).work.total);
     default:
-      // SortingTypes.NO_SORT
       break;
   }
 };
-
-export const sortTasks = (
-  taskList: Task[],
-  sortingType: SortingTypes,
-  sortingOrder: SortingOrders,
-) => sort(taskCompare(sortingType), sortingOrder)(taskList);
 
 // Function to help with reordering item in list
 export const reorderList = (

--- a/frontend/src/utils/array.ts
+++ b/frontend/src/utils/array.ts
@@ -1,0 +1,9 @@
+/**
+ * partition list based on predicate
+ * @returns [matching, rest]
+ */
+export const partition = <T>(list: T[], predicate: (t: T) => boolean) => {
+  const res: [T[], T[]] = [[], []];
+  list.forEach((x) => res[predicate(x) ? 0 : 1].push(x));
+  return res;
+};

--- a/frontend/src/utils/array.ts
+++ b/frontend/src/utils/array.ts
@@ -7,3 +7,22 @@ export const partition = <T>(list: T[], predicate: (t: T) => boolean) => {
   list.forEach((x) => res[predicate(x) ? 0 : 1].push(x));
   return res;
 };
+
+/**
+ * move elements inplace between lists
+ *
+ * the elements are first removed and then added back,
+ * so the destination index is the index after removal
+ *
+ * @param count how many elements to move
+ */
+
+export const move = (count: number = 1) =>
+  ({
+    from: <T>(src: T[], srcIndex: number) =>
+      ({
+        to: (dst: T[], dstIndex: number) => {
+          dst.splice(dstIndex, 0, ...src.splice(srcIndex, count));
+        },
+      } as const),
+  } as const);


### PR DESCRIPTION
- started to rewrite / reorganise task utils into (hopefully) reusable predicates
- rewrote sorting to
  - use decorate-sort-undecorate automatically for calculated keys
  - allow object property key as sorting key
  - use `undefined` as `NO_SORT`
- added `useSorting()` hook & SortingArrow component