### PR TITLE
Invitations

### DIFF
--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -331,6 +331,14 @@ const addInvitation = async (
   return response.status === 200;
 };
 
+const joinRoadmap = async (user: UserInfo, invitationLink: string) => {
+  const response = await axios.post(
+    `/users/${user.id}/join/${invitationLink}`,
+    { email: user.email },
+  );
+  return response.data as RoadmapRoleResponse;
+};
+
 export const api = {
   getRoadmaps,
   addRoadmap,
@@ -369,4 +377,5 @@ export const api = {
   patchIntegrationConfiguration,
   sendNotification,
   addInvitation,
+  joinRoadmap,
 };

--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -319,7 +319,7 @@ const sendNotification = async (
   return response.status === 200;
 };
 
-const sendInvitation = async (
+const addInvitation = async (
   email: string,
   type: RoleType,
   roadmapId: number,
@@ -368,5 +368,5 @@ export const api = {
   addIntegrationConfiguration,
   patchIntegrationConfiguration,
   sendNotification,
-  sendInvitation,
+  addInvitation,
 };

--- a/frontend/src/components/modals/AddTeamMemberModal.tsx
+++ b/frontend/src/components/modals/AddTeamMemberModal.tsx
@@ -42,14 +42,14 @@ export const AddTeamMemberModal: Modal<ModalTypes.ADD_TEAM_MEMBER_MODAL> = ({
 
     setIsLoading(true);
     const res = await dispatch(
-      roadmapsActions.sendInvitation({
+      roadmapsActions.addInvitation({
         email: formValues.email,
         type: formValues.type,
         roadmapId: chosenRoadmapId!,
       }),
     );
     setIsLoading(false);
-    if (roadmapsActions.sendInvitation.rejected.match(res)) {
+    if (roadmapsActions.addInvitation.rejected.match(res)) {
       if (res.payload?.message) setErrorMessage(res.payload.message);
       return;
     }

--- a/frontend/src/pages/JoinRoadmapPage.tsx
+++ b/frontend/src/pages/JoinRoadmapPage.tsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { useParams, useHistory } from 'react-router-dom';
+import { useDispatch, shallowEqual, useSelector } from 'react-redux';
+import { StoreDispatchType } from '../redux';
+import { userActions } from '../redux/user';
+import { RootState } from '../redux/types';
+import { userInfoSelector } from '../redux/user/selectors';
+import { UserInfo } from '../redux/user/types';
+import { paths } from '../routers/paths';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { requireLogin } from '../utils/requirelogin';
+
+export const JoinRoadmapPageComponent = () => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const history = useHistory();
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const { invitationLink } = useParams<{
+    invitationLink: string | undefined;
+  }>();
+
+  useEffect(() => {
+    if (!invitationLink || !userInfo) return;
+
+    setIsLoading(true);
+    dispatch(userActions.joinRoadmap({ user: userInfo, invitationLink })).then(
+      (res) => {
+        setIsLoading(false);
+        if (userActions.joinRoadmap.rejected.match(res)) {
+          if (res.payload) setErrorMessage(res.payload.message);
+          return;
+        }
+        history.push(
+          `${paths.roadmapHome}/${res.payload.roadmapId}${paths.roadmapRelative.dashboard}`,
+        );
+      },
+    );
+  }, [dispatch, history, invitationLink, userInfo]);
+
+  return (
+    <div>
+      {errorMessage ? <div>{errorMessage}</div> : <div>Joining roadmap</div>}
+      {isLoading && <LoadingSpinner />}
+    </div>
+  );
+};
+
+export const JoinRoadmapPage = requireLogin(JoinRoadmapPageComponent);

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -515,14 +515,14 @@ export const notifyUsers = createAsyncThunk<
   }
 });
 
-export const sendInvitation = createAsyncThunk<
+export const addInvitation = createAsyncThunk<
   boolean,
   { email: string; type: RoleType; roadmapId: number },
   { rejectValue: AxiosError }
->('sendInvitation', async (invitationRequest, thunkAPI) => {
+>('addInvitation', async (invitationRequest, thunkAPI) => {
   const { email, type, roadmapId } = invitationRequest;
   try {
-    return await api.sendInvitation(email, type, roadmapId);
+    return await api.addInvitation(email, type, roadmapId);
   } catch (err) {
     return thunkAPI.rejectWithValue(err);
   }

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -27,7 +27,7 @@ import {
   patchVersion,
   removeTaskFromVersion,
   notifyUsers,
-  sendInvitation,
+  addInvitation,
 } from './actions';
 import {
   ADD_ROADMAP_FULFILLED,
@@ -135,5 +135,5 @@ export const roadmapsActions = {
   addTaskToVersion,
   removeTaskFromVersion,
   notifyUsers,
-  sendInvitation,
+  addInvitation,
 };

--- a/frontend/src/redux/user/actions.ts
+++ b/frontend/src/redux/user/actions.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
 import { UserLoginRequest, UserInfo, UserRegisterRequest } from './types';
 import { api } from '../../api/api';
+import { RoadmapRoleResponse } from '../roadmaps/types';
 
 export const getUserInfo = createAsyncThunk<
   UserInfo,
@@ -52,6 +53,19 @@ export const register = createAsyncThunk<
       return true;
     }
     return false;
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err);
+  }
+});
+
+export const joinRoadmap = createAsyncThunk<
+  RoadmapRoleResponse,
+  { user: UserInfo; invitationLink: string },
+  { rejectValue: AxiosError }
+>('joinRoadmap', async (joinRequest, thunkAPI) => {
+  const { user, invitationLink } = joinRequest;
+  try {
+    return await api.joinRoadmap(user, invitationLink);
   } catch (err) {
     return thunkAPI.rejectWithValue(err);
   }

--- a/frontend/src/redux/user/index.ts
+++ b/frontend/src/redux/user/index.ts
@@ -1,7 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { getUserInfo, login, logout, register } from './actions';
+import { getUserInfo, login, logout, register, joinRoadmap } from './actions';
 import { UserState } from './types';
-import { GET_USER_INFO_FULFILLED, LOGOUT_FULFILLED } from './reducers';
+import {
+  GET_USER_INFO_FULFILLED,
+  LOGOUT_FULFILLED,
+  JOIN_ROADMAP_FULFILLED,
+} from './reducers';
 
 const initialState: UserState = {
   info: undefined,
@@ -14,6 +18,7 @@ export const userSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(getUserInfo.fulfilled, GET_USER_INFO_FULFILLED);
     builder.addCase(logout.fulfilled, LOGOUT_FULFILLED);
+    builder.addCase(joinRoadmap.fulfilled, JOIN_ROADMAP_FULFILLED);
   },
 });
 
@@ -23,4 +28,5 @@ export const userActions = {
   login,
   logout,
   register,
+  joinRoadmap,
 };

--- a/frontend/src/redux/user/reducers.ts
+++ b/frontend/src/redux/user/reducers.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { UserState, UserInfo } from './types';
+import { RoadmapRoleResponse } from '../roadmaps/types';
 
 export const GET_USER_INFO_FULFILLED = (
   state: UserState,
@@ -10,4 +11,12 @@ export const GET_USER_INFO_FULFILLED = (
 
 export const LOGOUT_FULFILLED = (state: UserState) => {
   state.info = undefined;
+};
+
+export const JOIN_ROADMAP_FULFILLED = (
+  state: UserState,
+  action: PayloadAction<RoadmapRoleResponse>,
+) => {
+  if (!state.info) throw new Error('UserInfo has not been fetched yet');
+  state.info.roles.push(action.payload);
 };

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -15,6 +15,7 @@ import { UserInfoPage } from '../pages/UserInfoPage';
 import { paths } from './paths';
 import { RoadmapRouter } from './RoadmapRouter';
 import { CreateProjectPage } from '../pages/CreateProjectPage';
+import { JoinRoadmapPage } from '../pages/JoinRoadmapPage';
 
 const Home = () => {
   const loggedInUser = useSelector<RootState, UserInfo | undefined>(
@@ -43,6 +44,11 @@ const routes = [
   {
     path: paths.getStarted,
     component: () => <NavLayout Content={CreateProjectPage} />,
+    exact: false,
+  },
+  {
+    path: paths.joinRoadmap,
+    component: () => <NavLayout Content={JoinRoadmapPage} />,
     exact: false,
   },
   {

--- a/frontend/src/routers/paths.ts
+++ b/frontend/src/routers/paths.ts
@@ -6,6 +6,8 @@ export const paths = {
   registerPage: '/register',
   getStarted: '/getstarted',
   overview: '/overview',
+  joinRoadmap:
+    '/join/:invitationLink([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})',
   roadmapHome: '/roadmap',
   notFound: '/404',
   roadmapRouter: '/roadmap/:roadmapId([0-9]+)',

--- a/server/src/api/invitations/invitations.controller.ts
+++ b/server/src/api/invitations/invitations.controller.ts
@@ -1,0 +1,42 @@
+import { RouteHandlerFnc } from 'src/types/customTypes';
+import Invitation from './invitations.model';
+import uuid from 'uuid';
+
+export const addInvitations: RouteHandlerFnc = async (ctx) => {
+  const { type, email, roadmapId, ...others } = ctx.request.body;
+  if (Object.keys(others).length) return void (ctx.status = 400);
+
+  const created = await Invitation.query().insertAndFetch({
+    id: uuid.v4(),
+    roadmapId: Number(ctx.params.roadmapId),
+    type,
+    email,
+  });
+  return void (ctx.body = created);
+};
+
+export const patchInvitations: RouteHandlerFnc = async (ctx) => {
+  const { id, type, email, roadmapId, ...others } = ctx.request.body;
+  if (Object.keys(others).length) return void (ctx.status = 400);
+
+  const patched = await Invitation.query().patchAndFetchById(
+    ctx.params.invitationId,
+    { type, email },
+  );
+
+  if (patched) {
+    return void (ctx.body = patched);
+  } else {
+    return void (ctx.status = 404);
+  }
+};
+
+export const deleteInvitations: RouteHandlerFnc = async (ctx) => {
+  const numDeleted = await Invitation.query()
+    .where({
+      id: ctx.params.invitationId,
+    })
+    .delete();
+
+  ctx.status = numDeleted == 1 ? 200 : 404;
+};

--- a/server/src/api/invitations/invitations.model.ts
+++ b/server/src/api/invitations/invitations.model.ts
@@ -1,0 +1,21 @@
+import { Model } from 'objection';
+import { RoleType } from '../../../../shared/types/customTypes';
+
+export default class Invitation extends Model {
+  id!: string;
+  roadmapId!: number;
+  type!: RoleType;
+  email!: string;
+
+  static tableName = 'invitations';
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      roadmapId: { type: 'integer' },
+      type: { type: 'integer' },
+      email: { type: 'string', format: 'email', minLength: 1, maxLength: 255 },
+    },
+  };
+}

--- a/server/src/api/invitations/invitations.routes.ts
+++ b/server/src/api/invitations/invitations.routes.ts
@@ -1,0 +1,32 @@
+import KoaRouter from '@koa/router';
+import { requirePermission } from './../../utils/checkPermissions';
+import { Context } from 'koa';
+import { IKoaState } from '../../types/customTypes';
+import { Permission } from '../../../../shared/types/customTypes';
+import {
+  addInvitations,
+  patchInvitations,
+  deleteInvitations,
+} from './invitations.controller';
+
+const invitationsRouter = new KoaRouter<IKoaState, Context>();
+
+invitationsRouter.post(
+  '/invitations',
+  requirePermission(Permission.RoadmapInvite),
+  addInvitations,
+);
+
+invitationsRouter.patch(
+  '/invitations/:invitationId',
+  requirePermission(Permission.RoadmapInvite),
+  patchInvitations,
+);
+
+invitationsRouter.delete(
+  '/invitations/:invitationId',
+  requirePermission(Permission.RoadmapInvite),
+  deleteInvitations,
+);
+
+export default invitationsRouter;

--- a/server/src/api/roadmaps/roadmaps.routes.ts
+++ b/server/src/api/roadmaps/roadmaps.routes.ts
@@ -16,6 +16,7 @@ import tasksRouter from '../tasks/tasks.routes';
 import integrationRouter from '../integration/integration.routes';
 import customerRouter from '../customer/customer.routes';
 import rolesRouter from '../roles/roles.routes';
+import invitationsRouter from '../invitations/invitations.routes';
 
 const roadmapRouter = new KoaRouter<IKoaState, Context>();
 
@@ -52,7 +53,11 @@ roadmapRouter.use('/roadmaps/:roadmapId', integrationRouter.allowedMethods());
 
 roadmapRouter.use('/roadmaps/:roadmapId', customerRouter.routes());
 roadmapRouter.use('/roadmaps/:roadmapId', customerRouter.allowedMethods());
+
 roadmapRouter.use('/roadmaps/:roadmapId', rolesRouter.routes());
 roadmapRouter.use('/roadmaps/:roadmapId', rolesRouter.allowedMethods());
+
+roadmapRouter.use('/roadmaps/:roadmapId', invitationsRouter.routes());
+roadmapRouter.use('/roadmaps/:roadmapId', invitationsRouter.allowedMethods());
 
 export default roadmapRouter;

--- a/server/src/api/users/users.routes.ts
+++ b/server/src/api/users/users.routes.ts
@@ -15,6 +15,7 @@ import {
   loginUser,
   getCurrentUser,
   logoutUser,
+  joinRoadmap,
 } from './users.controller';
 import { Context } from 'koa';
 import { IKoaState } from 'src/types/customTypes';
@@ -35,5 +36,6 @@ userRouter.post('/users/login', loginUser);
 userRouter.get('/users/logout', logoutUser);
 userRouter.get('/users/whoami', requireAuth, getCurrentUser);
 userRouter.get('/users/roles', requireAuth, getUserRoles);
+userRouter.post('/users/:userId/join/:invitationId', requireAuth, joinRoadmap);
 
 export default userRouter;

--- a/server/src/migrations/20210816112955_addInvitations.ts
+++ b/server/src/migrations/20210816112955_addInvitations.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.createTable('invitations', (table) => {
+    table.uuid('id').primary().index();
+    table
+      .integer('roadmapId')
+      .references('id')
+      .inTable('roadmaps')
+      .onDelete('CASCADE');
+    table.integer('type');
+    table.string('email', 75);
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  knex.schema.dropTableIfExists('invitations');
+}

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -35,6 +35,8 @@ export enum Permission {
   CustomerRepresent = 1 << 20,
 
   IntegrationConfigurationEdit = 1 << 21,
+
+  RoadmapInvite = 1 << 22,
 }
 
 export enum RoleType {


### PR DESCRIPTION
### Backend:
Added an invitation table, with the invitation id (uuid v4), roadmapId and RoleType of the invitation and email of the invited.

Added routes for adding, patching and deleting invitations, as well as using a invitation. On use the invitation is deleted.


### Frontend:
Route for joining is /join/:joiningLink. The joining link follows uuid v4 pattern. User needs to be logged in or register in order to join. 
- on successful join, user is redirected to the roadmap's dashboard page
- on unsuccessful join, an error message is displayed - perhaps a better design should be asked for

Frontend can be tested by adding a team member as an admin, logging out and using the created invitation id in the joining route.