### PR TITLE
Adjust frontend to permission model

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -16,9 +16,9 @@ import { roadmapsActions } from '../redux/roadmaps';
 import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
-import { RoleType } from '../../../shared/types/customTypes';
+import { RoleType, Permission } from '../../../shared/types/customTypes';
 import { splitTasksOnRated } from '../utils/TaskUtils';
-import { getType } from '../utils/UserUtils';
+import { getType, hasPermission } from '../utils/UserUtils';
 import css from './DashboardPage.module.scss';
 
 const classes = classNames.bind(css);
@@ -39,6 +39,7 @@ export const DashboardPage = () => {
     chosenRoadmapSelector,
     shallowEqual,
   );
+  const type = getType(userInfo?.roles, currentRoadmap?.id);
   const roadmapsVersions = currentRoadmap?.versions;
   const [chartVersionLists, setChartVersionLists] = useState<
     {
@@ -50,9 +51,13 @@ export const DashboardPage = () => {
   const [unratedTasks, setUnratedTasks] = useState<Task[]>([]);
 
   useEffect(() => {
-    if (!roadmapsVersions && currentRoadmap)
+    if (
+      !roadmapsVersions &&
+      currentRoadmap &&
+      hasPermission(type, Permission.VersionRead)
+    )
       dispatch(roadmapsActions.getVersions(currentRoadmap.id));
-  }, [currentRoadmap, dispatch, roadmapsVersions]);
+  }, [currentRoadmap, dispatch, roadmapsVersions, type]);
 
   // TODO move duplicate version organizing / charting logic into custom hook
   useEffect(() => {
@@ -102,7 +107,7 @@ export const DashboardPage = () => {
         </h2>
         <RoadmapOverview />
       </div>
-      {getType(userInfo?.roles, currentRoadmap?.id) === RoleType.Admin && (
+      {type === RoleType.Admin && (
         <div className={classes(css.chartFlexbox)}>
           <div className={classes(css.meterWrapper)}>
             <TaskHeatmap />

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -14,6 +14,10 @@ import { TaskListPage } from '../pages/TaskListPage';
 import { PeopleListPage } from '../pages/PeopleListPage';
 import { StoreDispatchType } from '../redux';
 import { roadmapsActions } from '../redux/roadmaps';
+import { userInfoSelector } from '../redux/user/selectors';
+import { UserInfo } from '../redux/user/types';
+import { getType, hasPermission } from '../utils/UserUtils';
+import { Permission } from '../../../shared/types/customTypes';
 import {
   chosenRoadmapSelector,
   roadmapUsersSelector,
@@ -62,6 +66,11 @@ const RoadmapRouterComponent = () => {
     chosenRoadmapSelector,
     shallowEqual,
   );
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const type = getType(userInfo?.roles, currentRoadmap?.id);
   const [isLoadingRoadmap, setIsLoadingRoadmap] = useState(false);
   const [isLoadingUsers, setIsLoadingUsers] = useState(false);
   const [useEffectFinished, setUseEffectFinished] = useState(false);
@@ -86,20 +95,28 @@ const RoadmapRouterComponent = () => {
         setIsLoadingRoadmap(false);
       });
     }
-    if (!roadmapUsers && currentRoadmap) {
+    if (
+      !roadmapUsers &&
+      currentRoadmap &&
+      hasPermission(type, Permission.RoadmapReadUsers)
+    ) {
       setIsLoadingUsers(true);
       dispatch(roadmapsActions.getRoadmapUsers(currentRoadmap.id)).then(() => {
         setIsLoadingUsers(false);
       });
     }
-    if (!customers && currentRoadmap) {
+    if (
+      !customers &&
+      currentRoadmap &&
+      hasPermission(type, Permission.RoadmapReadUsers)
+    ) {
       setIsLoadingCustomers(true);
       dispatch(roadmapsActions.getCustomers(currentRoadmap.id)).then(() => {
         setIsLoadingCustomers(false);
       });
     }
     setUseEffectFinished(true);
-  }, [currentRoadmap, roadmapId, dispatch, roadmapUsers, customers]);
+  }, [currentRoadmap, roadmapId, dispatch, roadmapUsers, customers, type]);
 
   const renderOrRedirect = () => {
     if (!useEffectFinished) return;

--- a/frontend/src/utils/UserUtils.ts
+++ b/frontend/src/utils/UserUtils.ts
@@ -1,5 +1,7 @@
+/* eslint-disable no-bitwise */
 import { RoadmapRole, UserInfo } from '../redux/user/types';
 import { Customer, RoadmapUser } from '../redux/roadmaps/types';
+import { RoleType } from '../../../shared/types/customTypes';
 
 export const getType = (
   roles: RoadmapRole[] | undefined,
@@ -17,3 +19,6 @@ export const representsCustomers = (user: UserInfo, roadmapId: number) =>
   !!user.representativeFor?.some(
     (customer) => customer.roadmapId === roadmapId,
   );
+
+export const hasPermission = (type: RoleType | undefined, permission: number) =>
+  type !== undefined && (type & permission) === permission;


### PR DESCRIPTION
Many api routes would give 403 forbidden errors, when user is not admin.
Now api calls are made only if user has the required permission.