### PR TITLE
Remove local planner weights

### DIFF
--- a/frontend/src/components/CustomerListTable.tsx
+++ b/frontend/src/components/CustomerListTable.tsx
@@ -7,14 +7,9 @@ import { StoreDispatchType } from '../redux/index';
 import { roadmapsActions } from '../redux/roadmaps';
 import {
   allCustomersSelector,
-  plannerCustomerWeightsSelector,
   chosenRoadmapSelector,
 } from '../redux/roadmaps/selectors';
-import {
-  Customer,
-  PlannerCustomerWeight,
-  Roadmap,
-} from '../redux/roadmaps/types';
+import { Customer, Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from './modals/types';
@@ -35,10 +30,6 @@ export const CustomerList: FC<{
   search: string;
 }> = ({ search }) => {
   const [sortedCustomers, setSortedCustomers] = useState<Customer[]>([]);
-  const plannedWeights = useSelector<RootState, PlannerCustomerWeight[]>(
-    plannerCustomerWeightsSelector,
-    shallowEqual,
-  );
   const customers = useSelector<RootState, Customer[] | undefined>(
     allCustomersSelector(),
     shallowEqual,
@@ -50,10 +41,7 @@ export const CustomerList: FC<{
   const dispatch = useDispatch<StoreDispatchType>();
 
   const [sort, sorting] = useSorting(
-    useMemo(() => customerSort(currentRoadmap, plannedWeights), [
-      currentRoadmap,
-      plannedWeights,
-    ]),
+    useMemo(() => customerSort(currentRoadmap), [currentRoadmap]),
   );
 
   useEffect(() => {

--- a/frontend/src/components/TableCustomerRow.tsx
+++ b/frontend/src/components/TableCustomerRow.tsx
@@ -6,10 +6,7 @@ import { StoreDispatchType } from '../redux';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes, modalLink } from './modals/types';
 import { Customer, Roadmap } from '../redux/roadmaps/types';
-import {
-  customerWeightSelector,
-  chosenRoadmapSelector,
-} from '../redux/roadmaps/selectors';
+import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
 import { RootState } from '../redux/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
@@ -26,11 +23,7 @@ interface TableRowProps {
 }
 
 export const TableCustomerRow: FC<TableRowProps> = ({ customer }) => {
-  const { id, name, email, color } = customer;
-  const weight = useSelector<RootState, number>(
-    customerWeightSelector(customer),
-    shallowEqual,
-  );
+  const { id, name, email, color, weight } = customer;
   const dispatch = useDispatch<StoreDispatchType>();
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -94,8 +94,6 @@ export const english = {
       'Set different weighting for clients',
     'Weighting description':
       "Client weights affect the scaling of milestone's total values in roadmap graph. Weight of 0% will ignore the ratings of the client in question.",
-    'Weighting instructions':
-      'The effects of different weighting can be explored without saving.',
     'Client Weights': 'Client Weights',
     register: 'register',
     'New here?': 'New here?',

--- a/frontend/src/pages/PlannerWeightsPage.tsx
+++ b/frontend/src/pages/PlannerWeightsPage.tsx
@@ -1,38 +1,25 @@
 import { useEffect, useState } from 'react';
 import { Alert } from 'react-bootstrap';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import classNames from 'classnames';
-import InfoIcon from '@material-ui/icons/InfoOutlined';
 import { Slider } from '../components/forms/Slider';
 import {
-  plannerCustomerWeightsSelector,
   allCustomersSelector,
   chosenRoadmapSelector,
 } from '../redux/roadmaps/selectors';
-import {
-  PlannerCustomerWeight,
-  Customer,
-  Roadmap,
-} from '../redux/roadmaps/types';
+import { Customer, Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
 import { Dot } from '../components/Dot';
 import { StoreDispatchType } from '../redux';
 import { roadmapsActions } from '../redux/roadmaps';
-import { customerWeight } from '../utils/CustomerUtils';
 import { percent } from '../utils/string';
-import { InfoTooltip } from '../components/InfoTooltip';
 import css from './PlannerWeightsPage.module.scss';
 
 const classes = classNames.bind(css);
 
 export const PlannerWeightsPage = () => {
-  const { t } = useTranslation();
   const dispatch = useDispatch<StoreDispatchType>();
-  const customerWeights = useSelector<RootState, PlannerCustomerWeight[]>(
-    plannerCustomerWeightsSelector,
-    shallowEqual,
-  );
 
   const customers = useSelector<RootState, Customer[] | undefined>(
     allCustomersSelector(),
@@ -43,9 +30,14 @@ export const PlannerWeightsPage = () => {
     shallowEqual,
   );
 
+  const [localCustomers, setLocalCustomers] = useState(customers);
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const [noChanges, setNoChanges] = useState(true);
+
+  const customerWeight = (
+    { id, weight }: Customer,
+    locals: Customer[] | undefined,
+  ) => locals?.find((customer) => customer.id === id)?.weight ?? weight;
 
   useEffect(() => {
     if (!customers && currentRoadmap)
@@ -56,52 +48,25 @@ export const PlannerWeightsPage = () => {
     if (!currentRoadmap) dispatch(roadmapsActions.getRoadmaps());
   }, [dispatch, currentRoadmap]);
 
-  const resetWeights = () => {
-    dispatch(roadmapsActions.clearPlannerCustomerWeights());
+  const handleSliderChange = async (customerId: number, weight: number) => {
+    setLocalCustomers((previous) =>
+      previous!.map((customer) =>
+        customer.id === customerId ? { ...customer, weight } : customer,
+      ),
+    );
   };
 
-  useEffect(() => {
-    setNoChanges(
-      !customerWeights.some(({ customerId, weight }) => {
-        const saved = customers?.find(({ id }) => id === customerId)?.weight;
-        return weight !== saved;
-      }),
-    );
-  }, [customerWeights, customers]);
-
-  const saveWeights = () => {
+  const saveWeight = async (customerId: number, weight: number) => {
     if (saving) return;
     setSaving(true);
-    const updates = customerWeights
-      .filter(({ customerId, weight }) => {
-        const saved = customers?.find(({ id }) => id === customerId)?.weight;
-        return weight !== saved;
-      })
-      .map(({ customerId, weight }) =>
-        dispatch(roadmapsActions.patchCustomer({ id: customerId, weight })),
-      );
-    Promise.all(updates)
-      .then((results) => {
-        const error = results.reduce(
-          (err: string | undefined | false, res) =>
-            !err && roadmapsActions.patchCustomer.rejected.match(res)
-              ? res.payload?.message
-              : err,
-          false,
-        );
-        if (error !== false) {
-          setErrorMessage(error || 'Unknown error');
-        } else {
-          resetWeights();
-        }
-      })
-      .finally(() => {
-        setSaving(false);
-      });
-  };
-
-  const handleSliderChange = (customerId: number, weight: number) => {
-    dispatch(roadmapsActions.setPlannerCustomerWeight({ customerId, weight }));
+    const res = await dispatch(
+      roadmapsActions.patchCustomer({ id: customerId, weight }),
+    );
+    if (roadmapsActions.patchCustomer.rejected.match(res)) {
+      if (res.payload?.message) setErrorMessage(res.payload.message);
+      setLocalCustomers(customers);
+    }
+    setSaving(false);
   };
 
   return (
@@ -109,26 +74,7 @@ export const PlannerWeightsPage = () => {
       <header className={classes(css.weightsHeader)}>
         <h2 className={classes(css.title)}>
           <Trans i18nKey="Set different weighing for clients" />
-          <InfoTooltip title={t('tooltipMessage')}>
-            <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
-          </InfoTooltip>
         </h2>
-        <button
-          className="button-small-outlined"
-          type="button"
-          onClick={resetWeights}
-          disabled={saving || noChanges}
-        >
-          Reset
-        </button>
-        <button
-          className="button-small-filled"
-          type="submit"
-          onClick={saveWeights}
-          disabled={saving || noChanges}
-        >
-          Save
-        </button>
       </header>
       <Alert
         show={errorMessage.length > 0}
@@ -141,9 +87,6 @@ export const PlannerWeightsPage = () => {
       <div className={classes(css.description)}>
         <p>
           <Trans i18nKey="Weighting description" />
-        </p>
-        <p>
-          <Trans i18nKey="Weighting instructions" />
         </p>
       </div>
       {customers?.map((customer) => (
@@ -158,12 +101,15 @@ export const PlannerWeightsPage = () => {
             className={classes(css.slider)}
             min={0}
             max={2}
-            value={customerWeight(customer, customerWeights)}
-            defaultValue={customerWeight(customer, customerWeights)}
+            value={customerWeight(customer, localCustomers)}
+            defaultValue={customer.weight}
             step={0.25}
             valueLabelDisplay="auto"
             valueLabelFormat={(value) => percent().format(value)}
             marks
+            onChangeCommitted={(e, value) =>
+              saveWeight(customer.id, Number(value))
+            }
             onChange={(e, value) =>
               handleSliderChange(customer.id, Number(value))
             }

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -48,8 +48,6 @@ import {
   PATCH_TASK_FULFILLED,
   SELECT_CURRENT_ROADMAP,
   CLEAR_CURRENT_ROADMAP,
-  SET_PLANNER_CUSTOMER_WEIGHT,
-  CLEAR_PLANNER_CUSTOMER_WEIGHTS,
   ADD_INTEGRATION_CONFIGURATION_FULFILLED,
   PATCH_INTEGRATION_CONFIGURATION_FULFILLED,
   ADD_VERSION_FULFILLED,
@@ -70,8 +68,6 @@ export const roadmapsSlice = createSlice({
   reducers: {
     selectCurrentRoadmap: SELECT_CURRENT_ROADMAP,
     clearCurrentRoadmap: CLEAR_CURRENT_ROADMAP,
-    setPlannerCustomerWeight: SET_PLANNER_CUSTOMER_WEIGHT,
-    clearPlannerCustomerWeights: CLEAR_PLANNER_CUSTOMER_WEIGHTS,
   },
   extraReducers: (builder) => {
     builder.addCase(getRoadmaps.fulfilled, GET_ROADMAPS_FULFILLED);

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -1,6 +1,5 @@
 import { CaseReducer, PayloadAction } from '@reduxjs/toolkit';
 import {
-  PlannerCustomerWeight,
   IntegrationConfiguration,
   Customer,
   CustomerRequest,
@@ -233,36 +232,6 @@ export const SELECT_CURRENT_ROADMAP: CaseReducer<
 
 export const CLEAR_CURRENT_ROADMAP: CaseReducer<RoadmapsState> = (state) => {
   state.selectedRoadmapId = undefined;
-};
-
-export const SET_PLANNER_CUSTOMER_WEIGHT: CaseReducer<
-  RoadmapsState,
-  PayloadAction<PlannerCustomerWeight>
-> = (state, action) => {
-  const selectedRoadmap = state.roadmaps?.find(
-    (roadmap) => roadmap.id === state.selectedRoadmapId,
-  );
-  if (!selectedRoadmap) throw new Error('No roadmap has been selected');
-  const weights = selectedRoadmap.plannerCustomerWeights || [];
-  const existing = weights.find(
-    ({ customerId }) => customerId === action.payload.customerId,
-  );
-  if (existing) Object.assign(existing, action.payload);
-  if (!existing) {
-    weights.push(action.payload);
-  }
-  selectedRoadmap.plannerCustomerWeights = weights;
-};
-
-export const CLEAR_PLANNER_CUSTOMER_WEIGHTS: CaseReducer<
-  RoadmapsState,
-  PayloadAction<void>
-> = (state) => {
-  const selectedRoadmap = state.roadmaps?.find(
-    (roadmap) => roadmap.id === state.selectedRoadmapId,
-  );
-  if (!selectedRoadmap) throw new Error('No roadmap has been selected');
-  selectedRoadmap.plannerCustomerWeights = [];
 };
 
 export const ADD_INTEGRATION_CONFIGURATION_FULFILLED = (

--- a/frontend/src/redux/roadmaps/selectors.ts
+++ b/frontend/src/redux/roadmaps/selectors.ts
@@ -1,7 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../types';
-import { Roadmap, Customer } from './types';
-import { customerWeight } from '../../utils/CustomerUtils';
+import { Roadmap } from './types';
 
 export const roadmapsSelector = (state: RootState): Roadmap[] | undefined =>
   state.roadmaps.roadmaps;
@@ -61,17 +60,6 @@ export const roadmapUsersSelector = (roadmapId?: number) =>
 export const userSelector = (id: number) => {
   return createSelector(roadmapUsersSelector(), (users) =>
     users?.find((user) => user.id === id),
-  );
-};
-
-export const plannerCustomerWeightsSelector = createSelector(
-  chosenRoadmapSelector,
-  (roadmap) => roadmap?.plannerCustomerWeights || [],
-);
-
-export const customerWeightSelector = (customer: Customer) => {
-  return createSelector(plannerCustomerWeightsSelector, (planned) =>
-    customerWeight(customer, planned),
   );
 };
 

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -57,7 +57,6 @@ export interface Roadmap {
   tasks: Task[];
   users: RoadmapUser[] | undefined;
   customers: Customer[] | undefined;
-  plannerCustomerWeights: PlannerCustomerWeight[] | undefined;
   integrations: IntegrationConfiguration[];
   versions: Version[] | undefined;
 }
@@ -133,10 +132,6 @@ export interface ImportBoardRequest {
   };
 }
 
-export interface PlannerCustomerWeight {
-  customerId: number;
-  weight: number;
-}
 export interface OAuthURLResponse {
   url: URL;
   token: string;

--- a/frontend/src/utils/CustomerUtils.ts
+++ b/frontend/src/utils/CustomerUtils.ts
@@ -1,20 +1,10 @@
 import convert from 'color-convert';
-import {
-  Customer,
-  PlannerCustomerWeight,
-  CheckableUser,
-  RoadmapUser,
-} from '../redux/roadmaps/types';
+import { Customer, CheckableUser, RoadmapUser } from '../redux/roadmaps/types';
 import { UserInfo } from '../redux/user/types';
 
 export const isCustomer = (
   user: Customer | RoadmapUser | UserInfo,
 ): user is Customer => 'representatives' in user;
-
-export const customerWeight = (
-  { id, weight }: Customer,
-  planned?: PlannerCustomerWeight[],
-) => planned?.find((plan) => plan.customerId === id)?.weight ?? weight;
 
 const difference = (first: number, second: number) =>
   180 - Math.abs(Math.abs(first - second) - 180);

--- a/frontend/src/utils/SortCustomerUtils.ts
+++ b/frontend/src/utils/SortCustomerUtils.ts
@@ -1,10 +1,5 @@
-import {
-  Customer,
-  PlannerCustomerWeight,
-  Roadmap,
-} from '../redux/roadmaps/types';
+import { Customer, Roadmap } from '../redux/roadmaps/types';
 import { unratedTasksAmount } from './TaskUtils';
-import { customerWeight } from './CustomerUtils';
 
 import { SortBy, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
@@ -16,19 +11,16 @@ export enum CustomerSortingTypes {
   SORT_UNRATED,
 }
 
-export const customerSort = (
-  roadmap?: Roadmap,
-  plannedWeights?: PlannerCustomerWeight[],
-) => (type: CustomerSortingTypes | undefined): SortBy<Customer> => {
+export const customerSort = (roadmap?: Roadmap) => (
+  type: CustomerSortingTypes | undefined,
+): SortBy<Customer> => {
   switch (type) {
     case CustomerSortingTypes.SORT_NAME:
       return sortKeyLocale('name');
     case CustomerSortingTypes.SORT_EMAIL:
       return sortKeyLocale('email');
     case CustomerSortingTypes.SORT_VALUE:
-      return sortKeyNumeric((customer) =>
-        customerWeight(customer, plannedWeights),
-      );
+      return sortKeyNumeric('weight');
     case CustomerSortingTypes.SORT_COLOR:
       return sortKeyLocale('color');
     case CustomerSortingTypes.SORT_UNRATED:

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -5,7 +5,7 @@ import {
   Task,
   Taskrating,
 } from '../redux/roadmaps/types';
-import { customerWeight, isCustomer } from './CustomerUtils';
+import { isCustomer } from './CustomerUtils';
 import { UserInfo } from '../redux/user/types';
 import {
   RoleType,
@@ -174,9 +174,7 @@ const ratingValueAndCreator = (roadmap: Roadmap, notWeighted?: boolean) => (
   const ratingCreator = roadmap.customers?.find(
     ({ id }) => id === rating.forCustomer,
   );
-  const creatorWeight = ratingCreator
-    ? customerWeight(ratingCreator, roadmap.plannerCustomerWeights)
-    : 0;
+  const creatorWeight = ratingCreator?.weight ?? 0;
 
   return {
     value: notWeighted ? rating.value : rating.value * creatorWeight,


### PR DESCRIPTION
Since only admins see the planner page and only few might be present in a roadmap, the edition of user weights is saved instantaneously.