### PR TITLE
Add task relations model

### DIFF
--- a/server/src/api/taskrelation/taskrelation.controller.ts
+++ b/server/src/api/taskrelation/taskrelation.controller.ts
@@ -1,0 +1,40 @@
+import { RouteHandlerFnc } from '../../types/customTypes';
+import Task from '../tasks/tasks.model';
+import { TaskRelation } from './taskrelation.model';
+
+export const getRelations: RouteHandlerFnc = async (ctx) => {
+  const tasks = (
+    await Task.query().where({
+      roadmapId: Number(ctx.params.roadmapId),
+    })
+  ).map((t) => t.id);
+
+  ctx.body = await TaskRelation.query()
+    .whereIn('from', tasks)
+    .orWhereIn('to', tasks);
+};
+
+const tasksInRoadmap = async (roadmapId: number, taskIds: number[]) => {
+  const tasks = await Task.query().where({ roadmapId }).whereIn('id', taskIds);
+  return tasks.length === taskIds.length;
+};
+
+export const addRelation: RouteHandlerFnc = async (ctx) => {
+  const { from, to, type } = ctx.request.body;
+  if (
+    from !== to &&
+    (await tasksInRoadmap(Number(ctx.params.roadmapId), [from, to]))
+  ) {
+    ctx.body = await TaskRelation.query().insertAndFetch({ from, to, type });
+  } else {
+    ctx.status = 400;
+  }
+};
+
+export const deleteRelation: RouteHandlerFnc = async (ctx) => {
+  const { from, to, type } = ctx.request.body;
+  const deleted =
+    (await tasksInRoadmap(Number(ctx.params.roadmapId), [from, to])) &&
+    (await TaskRelation.query().where({ from, to, type }).delete());
+  ctx.status = deleted === 1 ? 200 : 404;
+};

--- a/server/src/api/taskrelation/taskrelation.model.ts
+++ b/server/src/api/taskrelation/taskrelation.model.ts
@@ -1,0 +1,25 @@
+import { Model } from 'objection';
+import { TaskRelationType } from '../../../../shared/types/customTypes';
+
+export class TaskRelation extends Model {
+  from!: number;
+  to!: number;
+  type!: TaskRelationType;
+
+  static tableName = 'taskrelation';
+  static idColumn = ['from', 'to', 'type'];
+
+  static jsonSchema = {
+    type: 'object',
+    required: ['from', 'to', 'type'],
+
+    properties: {
+      from: { type: 'integer' },
+      to: { type: 'integer' },
+      type: {
+        type: 'integer',
+        enum: [TaskRelationType.Dependency, TaskRelationType.Synergy],
+      },
+    },
+  };
+}

--- a/server/src/api/taskrelation/taskrelation.routes.ts
+++ b/server/src/api/taskrelation/taskrelation.routes.ts
@@ -1,0 +1,29 @@
+import KoaRouter from '@koa/router';
+import {
+  getRelations,
+  deleteRelation,
+  addRelation,
+} from './taskrelation.controller';
+import { requirePermission } from './../../utils/checkPermissions';
+import { Context } from 'koa';
+import { IKoaState } from '../../types/customTypes';
+import { Permission } from '../../../../shared/types/customTypes';
+const taskrelationRouter = new KoaRouter<IKoaState, Context>();
+
+taskrelationRouter.get(
+  '/relations',
+  requirePermission(Permission.TaskRead),
+  getRelations,
+);
+taskrelationRouter.post(
+  '/relations',
+  requirePermission(Permission.TaskRead | Permission.RoadmapEdit),
+  addRelation,
+);
+taskrelationRouter.delete(
+  '/relations',
+  requirePermission(Permission.TaskRead | Permission.RoadmapEdit),
+  deleteRelation,
+);
+
+export default taskrelationRouter;

--- a/server/src/api/tasks/tasks.routes.ts
+++ b/server/src/api/tasks/tasks.routes.ts
@@ -10,7 +10,11 @@ import { Context } from 'koa';
 import { IKoaState } from '../../types/customTypes';
 import { Permission } from '../../../../shared/types/customTypes';
 import taskratingRouter from '../taskratings/taskratings.routes';
+import taskrelationRouter from '../taskrelation/taskrelation.routes';
 const tasksRouter = new KoaRouter<IKoaState, Context>();
+
+tasksRouter.use('/tasks', taskrelationRouter.routes());
+tasksRouter.use('/tasks', taskrelationRouter.allowedMethods());
 
 tasksRouter.get(
   '/tasks',

--- a/server/src/migrations/20210823150208_taskRelations.ts
+++ b/server/src/migrations/20210823150208_taskRelations.ts
@@ -1,0 +1,27 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable('taskrelation', (table) => {
+    table
+      .integer('from')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('tasks')
+      .onDelete('CASCADE');
+    table
+      .integer('to')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('tasks')
+      .onDelete('CASCADE');
+    table.integer('type').unsigned().notNullable();
+
+    table.primary(['from', 'to', 'type']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists('taskrelation');
+}

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -1,3 +1,8 @@
+export enum TaskRelationType {
+  Dependency,
+  Synergy,
+}
+
 export enum TaskRatingDimension {
   BusinessValue = 0,
   RequiredWork = 1,


### PR DESCRIPTION
Endpoints: get, post, delete.
Patch doesn't really make so much sense for this.

The relations are returned as a list of directed edges, with the nodes `from` and `to`, and the `type` of the relation.