### PR TITLE
Refactor tests

### DIFF
--- a/server/src/api/users/users.model.ts
+++ b/server/src/api/users/users.model.ts
@@ -17,6 +17,7 @@ export default class User extends Password(Model) {
   defaultRoadmapId!: number | null;
 
   tokens!: Token[];
+  roadmaps!: Roadmap[];
 
   static tableName = 'users';
 

--- a/server/tests/setuptests.ts
+++ b/server/tests/setuptests.ts
@@ -3,6 +3,11 @@ import chaiHttp from 'chai-http';
 import chai from 'chai';
 chai.use(chaiHttp);
 
+export const agentData = {
+  username: 'AdminPerson1',
+  password: 'test',
+};
+
 before(async () => {
   app = await server;
   await knex.migrate.latest();
@@ -12,10 +17,7 @@ beforeEach(async () => {
   await knex.seed.run();
   loggedInAgent = chai.request.agent(app);
 
-  await loggedInAgent
-    .post('/users/login')
-    .type('json')
-    .send({ username: 'AdminPerson1', password: 'test' });
+  await loggedInAgent.post('/users/login').type('json').send(agentData);
 });
 
 afterEach(async () => {


### PR DESCRIPTION
Refactored roadmap tests to be more accurate

Most relevant changes:
-Compare data on API to DB
-Create agentData variable to remove hardcoded data around the code
-Add more accurate checks (eg. compare to actual number of roadmaps instead of >0 etc.)
-Take roadmap id's into account when checking whether update/delete worked so we can be sure that correct roadmaps change.
-Some code cleanup

I also added property `roadmaps!: Roadmap[]` to user so I could access their roadmaps. Is this fine or should there be another way?

Few questions:
-Do we need to add permission tests in GET and POST?
-Do we need to check if API and DB update or is one enough? Example of updating both in: `PATCH /roadmaps/:roadmapId - Should patch roadmap`