### PR TITLE
Skip server tests on frontend-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Continuous integration
-on: push
+on:
+  push:
+    paths-ignore:
+      - 'frontend/**'
 jobs:
   build-and-test:
     name: Test


### PR DESCRIPTION
The current tests only test the server, so it is unnecessary (and also misleading) to run those on frontend changes.

The only benefit from running tests each time is that brittle tests are more likely noticed.