### PR TITLE
Allow tasks in milestones regardless of ratings

### DIFF
--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -24,11 +24,7 @@ import {
 } from '../redux/roadmaps/selectors';
 import { Customer, Roadmap, Task, Version } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
-import {
-  not,
-  weightedTaskPriority,
-  hasMissingRatings,
-} from '../utils/TaskUtils';
+import { weightedTaskPriority } from '../utils/TaskUtils';
 import { sortKeyNumeric, sort, SortingOrders } from '../utils/SortUtils';
 import { move } from '../utils/array';
 import css from './MilestonesEditor.module.scss';
@@ -88,11 +84,7 @@ export const MilestonesEditor = () => {
     if (disableUpdates) return;
     if (roadmapsVersionsLocal === undefined) return;
     const newVersionLists: VersionListsObject = {};
-    const unversioned = new Map(
-      tasks
-        .filter(not(hasMissingRatings(currentRoadmap)))
-        .map((task) => [task.id, task]),
-    );
+    const unversioned = new Map(tasks.map((task) => [task.id, task]));
     roadmapsVersionsLocal.forEach((v) => {
       newVersionLists[v.id] = v.tasks;
       v.tasks.forEach((task) => unversioned.delete(task.id));


### PR DESCRIPTION
The tasks may be added to milestones, but the visualisations e.g. the
value/work graph only start displaying meaningful data once there are
some ratings (for both work and value).