### PR TITLE
Remove privatekey from integration response

### DIFF
--- a/server/src/api/integration/integration.model.ts
+++ b/server/src/api/integration/integration.model.ts
@@ -1,4 +1,4 @@
-import { Model } from 'objection';
+import { Model, Pojo } from 'objection';
 
 import { IntegrationConfig } from '../integration';
 
@@ -31,4 +31,11 @@ export default class Integration extends Model implements IntegrationConfig {
       roadmapId: { type: 'integer' },
     },
   };
+
+  $formatJson(json: Pojo): Pojo {
+    json = super.$formatJson(json);
+    // Make sure the privatekey is not sent in the response
+    json.privatekey = '';
+    return json;
+  }
 }


### PR DESCRIPTION
The private key is only needed to be sent from the frontend for adding
or updating. There is no reason to send it back.

Otherwise the private key would be visible to all the admins in the roadmap.