### PR TITLE
Editable text component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,6 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-select": "^4.3.1",
-    "react-textarea-autosize": "^8.3.3",
     "react-window": "^1.8.6",
     "recharts": "^2.0.10",
     "redux": "^4.1.0",

--- a/frontend/src/components/EditableText.module.scss
+++ b/frontend/src/components/EditableText.module.scss
@@ -1,3 +1,5 @@
+@import '../shared.scss';
+
 .flexGrow {
   align-self: center;
   max-width: 300px;

--- a/frontend/src/components/EditableText.module.scss
+++ b/frontend/src/components/EditableText.module.scss
@@ -1,0 +1,49 @@
+.flexGrow {
+  align-self: center;
+  max-width: 300px;
+  min-width: 100px;
+  flex-grow: 1;
+  div {
+    margin: 0px;
+  }
+}
+
+.value {
+  @extend .typography-body;
+  @extend .layout-row;
+  @extend .flexGrow;
+  align-items: center;
+
+  padding-left: 21px;
+  padding-bottom: 2px;
+  &.bold {
+    @extend .typography-body-bold;
+  }
+  &.unordered {
+    @extend .typography-pre-title;
+  }
+  &.completed {
+    @extend .unordered;
+    color: $COLOR_FOREST;
+  }
+}
+
+.input {
+  font-weight: unset;
+  background-color: $COLOR_CLOUD;
+  border: 1px solid $COLOR_BLACK40;
+  @extend .flexGrow;
+  &.bold {
+    @extend .typography-body-bold;
+  }
+}
+
+.buttonsDiv {
+  @extend .layout-column;
+  gap: 5px;
+}
+
+.editButtonDiv {
+  margin-top: auto;
+  margin-bottom: auto;
+}

--- a/frontend/src/components/EditableText.tsx
+++ b/frontend/src/components/EditableText.tsx
@@ -1,0 +1,138 @@
+import { TextareaAutosize } from '@material-ui/core';
+import classNames from 'classnames';
+import { FC, useEffect, useState } from 'react';
+import { Alert } from 'react-bootstrap';
+import { CloseButton, ConfirmButton, EditButton } from './forms/SvgButton';
+import { LoadingSpinner } from './LoadingSpinner';
+import css from './TaskOverview.module.scss';
+
+const classes = classNames.bind(css);
+
+interface WithButtonsProps {
+  onOk: (newValue: string) => string | undefined;
+  value: string;
+  isLoading: boolean;
+}
+
+const withButtons = (Component: typeof EditableText) => ({
+  ...props
+}: WithButtonsProps) => {
+  const [editOpen, setEditOpen] = useState(false);
+  const [editText, setEditText] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const { onOk, ...passThroughProps } = props;
+
+  const handleTextChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    setEditText(event.currentTarget.value);
+  };
+
+  const handleConfirm = () => {
+    const returnedError = onOk(editText);
+    if (returnedError) setErrorMessage(returnedError);
+    setEditText('');
+    setEditOpen(false);
+  };
+
+  const handleCancel = () => {
+    setErrorMessage('');
+    setEditText('');
+    setEditOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    switch (event.key) {
+      case 'Enter':
+        handleConfirm();
+        break;
+      case 'Escape':
+        handleCancel();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <>
+      <Component
+        editOpen={editOpen}
+        editText={editText}
+        onTextChange={handleTextChange}
+        onKeyDown={handleKeyDown}
+        errorMessage={errorMessage}
+        {...passThroughProps}
+      />
+      {editOpen ? (
+        <div className={classes(css.buttonsDiv)}>
+          <CloseButton onClick={handleCancel} />
+          {errorMessage === '' && <ConfirmButton onClick={handleConfirm} />}
+        </div>
+      ) : (
+        <div className={classes(css.editButtonDiv)}>
+          <EditButton
+            fontSize="medium"
+            onClick={() => {
+              setEditOpen(true);
+            }}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export const EditableText: FC<{
+  editOpen: boolean;
+  editText: string;
+  onTextChange: (event: React.FormEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  errorMessage: string;
+  value: string;
+  isLoading: boolean;
+}> = ({
+  editOpen,
+  editText,
+  onTextChange,
+  value,
+  errorMessage,
+  isLoading,
+  onKeyDown,
+}) => {
+  return (
+    <>
+      {editOpen ? (
+        <>
+          {isLoading && (
+            <div className={classes(css.flexGrow)}>
+              <LoadingSpinner />
+            </div>
+          )}
+          {!isLoading && errorMessage === '' && (
+            <TextareaAutosize
+              className={classes(css.input)}
+              value={editText}
+              onChange={onTextChange}
+              autoComplete="off"
+              rows={1}
+              onKeyDown={onKeyDown}
+            />
+          )}
+          {errorMessage !== '' && (
+            <div className={classes(css.flexGrow)}>
+              <Alert show={errorMessage.length > 0} variant="danger">
+                {errorMessage}
+              </Alert>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className={classes(css.value)}>{value}</div>
+        </>
+      )}
+    </>
+  );
+};
+
+export const EditableTextWithButtons = withButtons(EditableText);

--- a/frontend/src/components/Overview.module.scss
+++ b/frontend/src/components/Overview.module.scss
@@ -108,23 +108,3 @@
     }
   }
 }
-
-.input {
-  font-weight: unset;
-  background-color: $COLOR_CLOUD;
-  border: 1px solid $COLOR_BLACK40;
-  @extend .flexGrow;
-  &.bold {
-    @extend .typography-body-bold;
-  }
-}
-
-.buttonsDiv {
-  @extend .layout-column;
-  gap: 5px;
-}
-
-.editButtonDiv {
-  margin-top: auto;
-  margin-bottom: auto;
-}

--- a/frontend/src/components/Overview.tsx
+++ b/frontend/src/components/Overview.tsx
@@ -9,6 +9,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { EditButton, CloseButton, ConfirmButton } from './forms/SvgButton';
 import { LoadingSpinner } from './LoadingSpinner';
 import { MetricsSummary, MetricsProps } from './MetricsSummary';
+import { EditableTextWithButtons } from './EditableText';
 import { ReactComponent as PreviousArrow } from '../icons/expand_less.svg';
 import { ReactComponent as NextArrow } from '../icons/expand_more.svg';
 import css from './Overview.module.scss';
@@ -41,7 +42,10 @@ type OverviewProps = {
   onOverviewChange: (id: number) => void;
   metrics: MetricsProps[];
   data: OverviewData[][];
-  onDataEdit?: (editedField: string, edited: string) => Promise<string>;
+  onDataEditConfirm?: (
+    newValue: string,
+    fieldId: string,
+  ) => Promise<string | void>;
 };
 
 /**
@@ -62,9 +66,10 @@ type OverviewProps = {
  * columns. 'Format' property adds a css class to the value string/component.
  * 'Editable' true value indicates the data value can be changed. In this case, the
  * 'keyName' needs to be the edited value's key.
- * @param {function} props.onDataEdit If prop.data consist of editable values, this
+ * @param {function} props.onDataEditConfirm If prop.data consist of editable values, this
  * function needs to be provided. It should patch the overviewable object with the
- * updated value and return a string (error str on patch fail, otherwise an empty one)
+ * updated value and return a void Promise if successful. In case of an error, return a
+ * Promise containing an error string.
  */
 export const Overview: FC<OverviewProps> = ({
   backHref,
@@ -74,53 +79,9 @@ export const Overview: FC<OverviewProps> = ({
   onOverviewChange,
   metrics,
   data,
-  onDataEdit,
+  onDataEditConfirm,
 }) => {
   const { t } = useTranslation();
-  const [editedField, setEditedField] = useState('');
-  const [editText, setEditText] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
-
-  const openEditField = (fieldName: string, fieldValue: string) => {
-    setEditedField(fieldName);
-    setEditText(fieldValue);
-  };
-
-  const closeEditField = () => {
-    setEditedField('');
-    setEditText('');
-    setErrorMessage('');
-  };
-
-  const handleTextChange = (event: FormEvent<HTMLTextAreaElement>) => {
-    setEditText(event.currentTarget.value);
-  };
-
-  const handleConfirm = async () => {
-    if (editedField === '' || editText === '') {
-      setErrorMessage("Field can't be empty.");
-      return;
-    }
-    setIsLoading(true);
-    const error = await onDataEdit!(editedField, editText);
-    setIsLoading(false);
-    if (error === '') closeEditField();
-    else setErrorMessage(error);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    switch (event.key) {
-      case 'Enter':
-        handleConfirm();
-        break;
-      case 'Escape':
-        closeEditField();
-        break;
-      default:
-        break;
-    }
-  };
 
   return (
     <div className={classes(css.section)}>
@@ -158,56 +119,16 @@ export const Overview: FC<OverviewProps> = ({
               {column.map(({ label, keyName, value, format, editable }) => (
                 <div className={classes(css.row)} key={label}>
                   <div className={classes(css.label)}>{label}</div>
-                  {editedField === keyName ? (
-                    <>
-                      {isLoading && (
-                        <div className={classes(css.flexGrow)}>
-                          <LoadingSpinner />
-                        </div>
-                      )}
-                      {!isLoading && errorMessage === '' && (
-                        <TextareaAutosize
-                          className={classes(css.input, css[format ?? ''])}
-                          value={editText}
-                          onChange={(e) => handleTextChange(e)}
-                          autoComplete="off"
-                          rows={1}
-                          onKeyDown={handleKeyDown}
-                        />
-                      )}
-                      {errorMessage !== '' && (
-                        <div className={classes(css.flexGrow)}>
-                          <Alert
-                            show={errorMessage.length > 0}
-                            variant="danger"
-                            onClose={() => setErrorMessage('')}
-                          >
-                            {errorMessage}
-                          </Alert>
-                        </div>
-                      )}
-                      {editable && (
-                        <div className={classes(css.buttonsDiv)}>
-                          <CloseButton onClick={() => closeEditField()} />
-                          {errorMessage === '' && (
-                            <ConfirmButton onClick={handleConfirm} />
-                          )}
-                        </div>
-                      )}
-                    </>
+                  {editable ? (
+                    <EditableTextWithButtons
+                      onOk={onDataEditConfirm!}
+                      value={value}
+                      fieldId={keyName}
+                      format={format}
+                    />
                   ) : (
                     <>
-                      <div className={classes(css.value, css[format ?? ''])}>
-                        {value}
-                      </div>
-                      {editable && (
-                        <div className={classes(css.editButtonDiv)}>
-                          <EditButton
-                            fontSize="medium"
-                            onClick={() => openEditField(keyName, value)}
-                          />
-                        </div>
-                      )}
+                      <div className={classes(css.value)}>{value}</div>
                     </>
                   )}
                 </div>

--- a/frontend/src/components/Overview.tsx
+++ b/frontend/src/components/Overview.tsx
@@ -1,13 +1,9 @@
-import { FC, useState, FormEvent, KeyboardEvent } from 'react';
+import { FC } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { IconButton } from '@material-ui/core';
-import { Alert } from 'react-bootstrap';
-import TextareaAutosize from 'react-textarea-autosize';
-import { EditButton, CloseButton, ConfirmButton } from './forms/SvgButton';
-import { LoadingSpinner } from './LoadingSpinner';
 import { MetricsSummary, MetricsProps } from './MetricsSummary';
 import { EditableTextWithButtons } from './EditableText';
 import { ReactComponent as PreviousArrow } from '../icons/expand_less.svg';

--- a/frontend/src/components/forms/SvgButton.tsx
+++ b/frontend/src/components/forms/SvgButton.tsx
@@ -66,6 +66,10 @@ export const DeleteButton = svgButton(DeleteIcon, {
 export const ModalCloseButton = svgButton(CloseIcon, {
   className: classes(css.closeButton),
 });
-export const CloseButton = svgButton(CloseIcon, {});
-export const ConfirmButton = svgButton(CheckIcon, {});
+export const CloseButton = svgButton(CloseIcon, {
+  hoverColor: colors.raspberry,
+});
+export const ConfirmButton = svgButton(CheckIcon, {
+  hoverColor: colors.emerald,
+});
 export const MailButton = svgButton(MailIcon, { hoverColor: colors.azure });

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -98,16 +98,18 @@ const TaskOverview: FC<{
     ],
   ];
 
-  const handleEdit = async (editedField: string, edited: string) => {
+  const handleEditConfirm = async (newValue: string, fieldId: string) => {
     const req: TaskRequest = {
       id: task.id,
-      [editedField]: edited,
+      [fieldId]: newValue,
     };
 
     const res = await dispatch(roadmapsActions.patchTask(req));
-    if (roadmapsActions.patchTask.rejected.match(res) && res.payload)
-      return res.payload.message;
-    return '';
+    if (roadmapsActions.patchTask.rejected.match(res)) {
+      if (res.payload) {
+        return res.payload.message;
+      }
+    }
   };
 
   return (
@@ -120,7 +122,7 @@ const TaskOverview: FC<{
         onOverviewChange={(id) => history.push(`${tasksListPage}/${id}`)}
         metrics={metrics}
         data={taskData}
-        onDataEdit={handleEdit}
+        onDataEditConfirm={handleEditConfirm}
       />
       <div className={classes(css.ratings)}>
         {valueRatings.length > 0 && (

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10349,15 +10349,6 @@ react-smooth@^2.0.0:
     raf "^3.4.0"
     react-transition-group "2.9.0"
 
-react-textarea-autosize@^8.3.3:
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz#f70913945369da453fd554c168f6baacd1fa04d8"
-  integrity sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    use-composed-ref "^1.0.0"
-    use-latest "^1.0.0"
-
 react-transition-group@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -12006,11 +11997,6 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-essentials@^2.0.3:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
-  integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
-
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -12334,25 +12320,6 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-use-composed-ref@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.1.0.tgz#9220e4e94a97b7b02d7d27eaeab0b37034438bbc"
-  integrity sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==
-  dependencies:
-    ts-essentials "^2.0.3"
-
-use-isomorphic-layout-effect@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
-  integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
-
-use-latest@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.2.0.tgz#a44f6572b8288e0972ec411bdd0840ada366f232"
-  integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
-  dependencies:
-    use-isomorphic-layout-effect "^1.0.0"
 
 use-memo-one@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
A reusable component out of the editable text implemented in TaskOverview. Mostly made with the coming Profile page rework in mind.

Both a very narrowly controllable text field with edit/close/confirm buttons, and a more freely customisable field without buttons.