### PR TITLE
Add styling for handles that have connections

### DIFF
--- a/frontend/src/pages/TaskMapPage.module.scss
+++ b/frontend/src/pages/TaskMapPage.module.scss
@@ -55,6 +55,10 @@
   border: 2px solid $COLOR_ORANGE;
 }
 
+.filledLeftHandle {
+  background-color: $COLOR_ORANGE;
+}
+
 .rightHandle {
   position: absolute;
   left: 97%;
@@ -63,6 +67,10 @@
   width: 17px;
   background-color: $COLOR_WHITE;
   border: 2px solid $COLOR_FOREST;
+}
+
+.filledRightHandle {
+  background-color: $COLOR_FOREST;
 }
 
 .taskRatingTexts {


### PR DESCRIPTION
Now the handles (green and orange dots on each task) are filled when they have at least one connection