### PR TITLE
Add info icon to taskmap

### DIFF
--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -219,5 +219,7 @@ export const english = {
     'Client value': 'Client value',
     'Tasks rated': 'Tasks rated',
     'Unrated tasks': 'Unrated tasks',
+    'Taskmap-tooltip':
+      'You can delete relations by right clicking them or hovering over and pressing backspace or delete',
   },
 };

--- a/frontend/src/pages/TaskMapPage.module.scss
+++ b/frontend/src/pages/TaskMapPage.module.scss
@@ -80,3 +80,10 @@
 .taskRatingTexts {
   margin-left: auto;
 }
+
+.info {
+  position: relative;
+  left: 28px;
+  bottom: 26px;
+  width: 16px;
+}

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -3,6 +3,8 @@ import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import ReactFlow, { Handle, Controls } from 'react-flow-renderer';
 import classNames from 'classnames';
 import DoneAllIcon from '@material-ui/icons/DoneAll';
+import InfoIcon from '@material-ui/icons/InfoOutlined';
+import { useTranslation } from 'react-i18next';
 import { RootState } from '../redux/types';
 import {
   allTasksSelector,
@@ -20,6 +22,7 @@ import { TaskRelationType } from '../../../shared/types/customTypes';
 import { CustomEdge } from '../components/TaskMapEdge';
 import { ConnectionLine } from '../components/TaskMapConnection';
 import css from './TaskMapPage.module.scss';
+import { InfoTooltip } from '../components/InfoTooltip';
 
 const classes = classNames.bind(css);
 
@@ -121,6 +124,7 @@ const CustomNodeComponent: FC<{ data: any }> = ({ data }) => {
 };
 
 export const TaskMapPage = () => {
+  const { t } = useTranslation();
   const tasks = useSelector(allTasksSelector(), shallowEqual);
   const dispatch = useDispatch<StoreDispatchType>();
   const taskRelations = groupTaskRelations(tasks);
@@ -201,7 +205,13 @@ export const TaskMapPage = () => {
         }}
         elementsSelectable={false}
       >
-        <Controls showInteractive={false} showZoom={false} />
+        <Controls showInteractive={false} showZoom={false}>
+          <InfoTooltip title={t('Taskmap-tooltip')}>
+            <InfoIcon
+              className={classes(css.info, css.tooltipIcon, css.infoIcon)}
+            />
+          </InfoTooltip>
+        </Controls>
       </ReactFlow>
       <div className={classes(css.taskOverviewContainer)}>
         {selectedTask && (

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -532,3 +532,8 @@ textarea {
 .react-flow__edges {
   z-index: 3 !important;
 }
+
+.react-flow__controls {
+  height: 27px;
+  width: 26px;
+}


### PR DESCRIPTION
Added info-icon next to the center-map icon in Task map. Info text currently gives tips about deleting relations.