### PR TITLE
Block timeline

### DIFF
--- a/frontend/src/components/BlockGraph.module.scss
+++ b/frontend/src/components/BlockGraph.module.scss
@@ -1,0 +1,79 @@
+@import '../shared.scss';
+
+$GRAPH_ITEM_MARGIN: 11px;
+
+.graphOuter {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  max-height: 500px;
+  min-height: 500px;
+  margin-left: 20px;
+  overflow-x: auto;
+}
+
+.graphLabel {
+  @extend .typography-pre-title;
+  color: $COLOR_BLACK40;
+  &.vertical {
+    width: 100px;
+    transform: rotate(-90deg);
+    position: relative;
+    left: -43px;
+    top: -250px;
+  }
+  &:not(.vertical) {
+    margin-top: 9px;
+  }
+}
+
+.graphInner {
+  border-left: 1px solid $COLOR_BLACK40;
+  border-bottom: 1px solid $COLOR_BLACK40;
+}
+
+.viewContainer {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  overflow-x: auto;
+  justify-content: flex-start;
+  align-items: flex-end;
+  padding-bottom: 20px;
+  padding-left: 23px;
+}
+
+.viewItems {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-end;
+  overflow-x: visible;
+}
+
+.graphItem {
+  @extend .shadow-roadmapblock;
+  display: flex;
+  flex-direction: column;
+  overflow-x: visible;
+  border-radius: 8px;
+  margin-right: $GRAPH_ITEM_MARGIN;
+  padding: 8px;
+  background-color: white;
+  cursor: pointer;
+  border: 1px solid transparent;
+
+  &:hover,
+  &:focus {
+    outline: none;
+    border: 1px solid $COLOR_SKY;
+    transform: scale(0.99, 0.99);
+  }
+  &:active {
+    transform: scale(0.97, 0.97);
+  }
+  &.selected {
+    background: $COLOR_CLOUD;
+  }
+  user-select: none;
+}

--- a/frontend/src/components/BlockGraph.tsx
+++ b/frontend/src/components/BlockGraph.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { RefObject, ReactNode } from 'react';
 import classNames from 'classnames';
 import css from './BlockGraph.module.scss';
 
@@ -56,6 +56,7 @@ interface BlockViewProps<T> {
     height: number;
   }) => ReactNode;
   className?: string;
+  innerRef?: RefObject<HTMLDivElement>;
 }
 
 type BlockGraphProps<T> = {
@@ -75,9 +76,10 @@ export function BlockView<T>({
   origin = 0,
   children,
   className,
+  innerRef,
 }: BlockViewProps<T>) {
   return (
-    <div className={classes(css.viewContainer, className)}>
+    <div ref={innerRef} className={classes(css.viewContainer, className)}>
       <div className={classes(css.viewItems)}>
         {sizing(items.slice(origin), dimensions, limits).map((props, idx) =>
           children({ ...props, index: origin + idx }),

--- a/frontend/src/components/BlockGraph.tsx
+++ b/frontend/src/components/BlockGraph.tsx
@@ -1,0 +1,138 @@
+import { ReactNode } from 'react';
+import classNames from 'classnames';
+import css from './BlockGraph.module.scss';
+
+const classes = classNames.bind(css);
+
+const lerp = (values: number[], lo: number, hi: number) => {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  return values.map(
+    (x) => lo + Math.floor(((x - min) / (max - min)) * (hi - lo)),
+  );
+};
+
+interface DimensionLimits {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+type DimensionFn<T> = (
+  item: T,
+  idx: number,
+) => { width: number; height: number };
+
+function sizing<T>(
+  items: T[],
+  dimensions: DimensionFn<T>,
+  limits: DimensionLimits,
+) {
+  const sizes = items.map(dimensions);
+  const w = lerp(
+    sizes.map((x) => x.width),
+    limits.minWidth,
+    limits.maxWidth,
+  );
+  const h = lerp(
+    sizes.map((x) => x.height),
+    limits.minHeight,
+    limits.maxHeight,
+  );
+  return items.map((item, i) => ({ item, width: w[i], height: h[i] }));
+}
+
+/* eslint-disable react/require-default-props */
+interface BlockViewProps<T> {
+  items: T[];
+  origin?: number;
+  dimensions: DimensionFn<T>;
+  limits: DimensionLimits;
+  children: (props: {
+    item: T;
+    index: number;
+    width: number;
+    height: number;
+  }) => ReactNode;
+  className?: string;
+}
+
+type BlockGraphProps<T> = {
+  title: ReactNode;
+  xLabel: ReactNode;
+  yLabel: ReactNode;
+  selected: number;
+  setSelected: (_: number) => void;
+  id: (item: T) => string | number;
+  children: (props: { item: T; selected: boolean }) => ReactNode;
+} & Omit<BlockViewProps<T>, 'children'>;
+
+export function BlockView<T>({
+  items,
+  dimensions,
+  limits,
+  origin = 0,
+  children,
+  className,
+}: BlockViewProps<T>) {
+  return (
+    <div className={classes(css.viewContainer, className)}>
+      <div className={classes(css.viewItems)}>
+        {sizing(items.slice(origin), dimensions, limits).map((props, idx) =>
+          children({ ...props, index: origin + idx }),
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function BlockGraph<T>({
+  title,
+  xLabel,
+  yLabel,
+  selected,
+  setSelected,
+  id,
+  children,
+  ...viewProps
+}: BlockGraphProps<T>) {
+  return (
+    <>
+      <div className={classes(css.graphOuter)}>
+        {title}
+        <BlockView {...viewProps} className={classes(css.graphInner)}>
+          {({ item, index, width, height }) => (
+            <div
+              ref={
+                index === selected
+                  ? (e) => {
+                      if (e)
+                        e.scrollIntoView({
+                          behavior: 'smooth',
+                          block: 'nearest',
+                          inline: 'center',
+                        });
+                    }
+                  : undefined
+              }
+              className={classes(css.graphItem, {
+                [css.selected]: index === selected,
+              })}
+              style={{ width, height }}
+              key={id(item)}
+              onClick={() => setSelected(index)}
+              onKeyPress={() => setSelected(index)}
+              role="button"
+              tabIndex={0}
+            >
+              {children({ item, selected: index === selected })}
+            </div>
+          )}
+        </BlockView>
+        <p className={classes(css.graphLabel)}>{xLabel}</p>
+      </div>
+      <p className={classes(css.graphLabel, css.vertical)}>{yLabel}</p>
+    </>
+  );
+}

--- a/frontend/src/components/BlockGraph.tsx
+++ b/frontend/src/components/BlockGraph.tsx
@@ -7,7 +7,7 @@ const classes = classNames.bind(css);
 /**
  * Linear interpolation of `values` to the interval [`low`, `high`)
  */
-const lerp = (values: number[], low: number, high: number) => {
+const mapToRange = (values: number[], low: number, high: number) => {
   const min = Math.min(...values);
   const max = Math.max(...values);
   return values.map(
@@ -33,12 +33,12 @@ function sizing<T>(
   limits: DimensionLimits,
 ) {
   const sizes = items.map(dimensions);
-  const w = lerp(
+  const w = mapToRange(
     sizes.map((x) => x.width),
     limits.minWidth,
     limits.maxWidth,
   );
-  const h = lerp(
+  const h = mapToRange(
     sizes.map((x) => x.height),
     limits.minHeight,
     limits.maxHeight,

--- a/frontend/src/components/BlockGraph.tsx
+++ b/frontend/src/components/BlockGraph.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, Ref, ReactNode } from 'react';
+import { useRef, CSSProperties, Ref, ReactNode } from 'react';
 import classNames from 'classnames';
 import css from './BlockGraph.module.scss';
 
@@ -122,24 +122,34 @@ export function BlockGraph<T>({
   setSelected,
   id,
   children,
+  innerRef,
   ...viewProps
 }: BlockGraphProps<T>) {
+  const ref = useRef<HTMLDivElement | null>(null);
   return (
     <>
       <div className={classes(css.graphOuter)}>
         {title}
-        <BlockView {...viewProps} className={classes(css.graphInner)}>
+        <BlockView
+          innerRef={(e) => {
+            if (e) ref.current = e;
+            if (typeof innerRef === 'function') innerRef(e);
+          }}
+          {...viewProps}
+          className={classes(css.graphInner)}
+        >
           {({ item, index, width, height }) => (
             <div
               ref={
                 index === selected
                   ? (e) => {
-                      if (e)
-                        e.scrollIntoView({
+                      if (e) {
+                        ref.current?.scrollTo({
+                          top: e.offsetTop,
+                          left: e.offsetLeft - ref.current.offsetLeft,
                           behavior: 'smooth',
-                          block: 'nearest',
-                          inline: 'center',
                         });
+                      }
                     }
                   : undefined
               }

--- a/frontend/src/components/BlockGraph.tsx
+++ b/frontend/src/components/BlockGraph.tsx
@@ -1,14 +1,17 @@
-import { RefObject, ReactNode } from 'react';
+import { CSSProperties, Ref, ReactNode } from 'react';
 import classNames from 'classnames';
 import css from './BlockGraph.module.scss';
 
 const classes = classNames.bind(css);
 
-const lerp = (values: number[], lo: number, hi: number) => {
+/**
+ * Linear interpolation of `values` to the interval [`low`, `high`)
+ */
+const lerp = (values: number[], low: number, high: number) => {
   const min = Math.min(...values);
   const max = Math.max(...values);
   return values.map(
-    (x) => lo + Math.floor(((x - min) / (max - min)) * (hi - lo)),
+    (x) => low + Math.floor(((x - min) / (max - min)) * (high - low)),
   );
 };
 
@@ -65,7 +68,8 @@ interface BlockViewProps<T> {
     height: number;
   }) => ReactNode;
   className?: string;
-  innerRef?: RefObject<HTMLDivElement>;
+  innerRef?: Ref<HTMLDivElement>;
+  style?: CSSProperties;
 }
 
 type BlockGraphProps<T> = {
@@ -87,10 +91,15 @@ export function BlockView<T>({
   children,
   className,
   innerRef,
+  style,
 }: BlockViewProps<T>) {
   let x = x0;
   return (
-    <div ref={innerRef} className={classes(css.viewContainer, className)}>
+    <div
+      ref={innerRef}
+      className={classes(css.viewContainer, className)}
+      style={style}
+    >
       <div className={classes(css.viewItems)}>
         {sizing(items, dimensions, limits).map(
           ({ original, scaled, ...props }, index) => {

--- a/frontend/src/components/TaskValueCreatedVisualization.module.scss
+++ b/frontend/src/components/TaskValueCreatedVisualization.module.scss
@@ -1,5 +1,5 @@
 @import './../shared.scss';
-@import './../pages/RoadmapGraphPage.module.scss';
+@import './BlockGraph.module.scss';
 
 $MAX_DIAMETER: calc(60px * var(--max-diameter-multiplier));
 $LARGEST_DOT_DIAMETER: calc(#{$MAX_DIAMETER} * var(--largest-dot-size, 0.3));

--- a/frontend/src/components/TaskValueCreatedVisualization.tsx
+++ b/frontend/src/components/TaskValueCreatedVisualization.tsx
@@ -19,14 +19,14 @@ interface VersionWorkAndTotalValue extends Version {
 
 export const TaskValueCreatedVisualization: FC<{
   version: VersionWorkAndTotalValue;
-}> = ({ version }) => {
+  width: number;
+}> = ({ version, width }) => {
   const dispatch = useDispatch<StoreDispatchType>();
   const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
     chosenRoadmapSelector,
     shallowEqual,
   );
   const [data, setData] = useState<CustomerStakes[]>([]);
-  const w = Math.max(100, 60 * (version.work / 5));
 
   useEffect(() => {
     if (!currentRoadmap) {
@@ -57,7 +57,7 @@ export const TaskValueCreatedVisualization: FC<{
     <div
       className={classes(css.customerStakes)}
       style={{
-        ['--version-width' as any]: `${w}px`,
+        ['--version-width' as any]: `${width}px`,
         ['--largest-dot-size' as any]: largestValue(data),
         ['--max-diameter-multiplier' as any]: Math.min(
           2,

--- a/frontend/src/pages/RoadmapGraphPage.module.scss
+++ b/frontend/src/pages/RoadmapGraphPage.module.scss
@@ -1,17 +1,5 @@
 @import '../shared.scss';
 
-$GRAPH_ITEM_MARGIN: 11px;
-
-.graphOuter {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  max-height: 500px;
-  min-height: 500px;
-  margin-left: 20px;
-  overflow-x: auto;
-}
-
 .titleContainer {
   display: flex;
   line-height: 150%;
@@ -29,69 +17,6 @@ $GRAPH_ITEM_MARGIN: 11px;
   }
 }
 
-.graphLabel {
-  @extend .typography-pre-title;
-  color: $COLOR_BLACK40;
-  &.vertical {
-    width: 100px;
-    transform: rotate(-90deg);
-    position: relative;
-    left: -43px;
-    top: -250px;
-  }
-  &:not(.vertical) {
-    margin-top: 9px;
-  }
-}
-
-.graphInner {
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1;
-  overflow-x: auto;
-  border-left: 1px solid $COLOR_BLACK40;
-  border-bottom: 1px solid $COLOR_BLACK40;
-  justify-content: flex-start;
-  align-items: flex-end;
-  padding-left: 23px;
-  padding-bottom: 20px;
-}
-
-.graphItems {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: flex-end;
-  overflow-x: visible;
-}
-
-.graphItem {
-  @extend .shadow-roadmapblock;
-  display: flex;
-  flex-direction: column;
-  overflow-x: visible;
-  border-radius: 8px;
-  margin-right: $GRAPH_ITEM_MARGIN;
-  padding: 8px;
-  background-color: white;
-  cursor: pointer;
-  border: 1px solid transparent;
-
-  &:hover,
-  &:focus {
-    outline: none;
-    border: 1px solid $COLOR_SKY;
-    transform: scale(0.99, 0.99);
-  }
-  &:active {
-    transform: scale(0.97, 0.97);
-  }
-  &.selected {
-    background: $COLOR_CLOUD;
-  }
-  user-select: none;
-}
-
 .footer {
   min-height: 200px;
   margin-left: 20px;
@@ -101,7 +26,6 @@ $GRAPH_ITEM_MARGIN: 11px;
 .stakesContainer {
   display: flex;
   flex-direction: row;
-  margin-left: 24px;
 }
 
 .versionData {

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -48,29 +48,18 @@ export const RoadmapGraphPage = () => {
   // TODO: scrolling selected into view from BlockGraph doesn't work with this
   const a = useRef<HTMLDivElement>(null);
   const b = useRef<HTMLDivElement>(null);
-  const refs = useRef([a, b]);
-  const scrolling = useRef(0);
 
   useEffect(() => {
-    const handleScroll = (e: any) => {
-      if (scrolling.current) {
-        scrolling.current = 0;
-        return;
-      }
+    const ac = a.current;
+    const bc = b.current;
+    if (!ac || !bc) return;
 
-      scrolling.current = 1;
-      const other = e.target === a.current ? b : a;
-
-      window.requestAnimationFrame(() =>
-        other.current?.scroll({ left: e.target.scrollLeft }),
-      );
+    const handleScroll = () => {
+      window.requestAnimationFrame(() => bc.scroll({ left: ac.scrollLeft }));
     };
-
-    const elements = [a.current, b.current];
-    elements.forEach((el) => el?.addEventListener('scroll', handleScroll));
-    return () =>
-      elements.forEach((el) => el?.removeEventListener('scroll', handleScroll));
-  }, [refs, scrolling]);
+    ac.addEventListener('scroll', handleScroll);
+    return () => ac.removeEventListener('scroll', handleScroll);
+  }, []);
 
   useEffect(() => {
     if (!currentRoadmap) dispatch(roadmapsActions.getRoadmaps());
@@ -172,6 +161,7 @@ export const RoadmapGraphPage = () => {
             dimensions={dimensions}
             limits={limits}
             innerRef={b}
+            style={{ overflowX: 'hidden' }}
           >
             {({ item: ver, width }) => (
               <TaskValueCreatedVisualization

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -128,7 +128,7 @@ export const RoadmapGraphPage = () => {
         limits={limits}
         innerRef={a}
       >
-        {({ item: { name, value, work, tasks }, selected }) => (
+        {({ item: { name, value, work, tasks }, index }) => (
           <>
             <div className={classes(css.versionData)}>
               <div className={classes(css.ratingDiv)}>
@@ -147,7 +147,7 @@ export const RoadmapGraphPage = () => {
             </div>
             <p
               className={classes(css.versionTitle, {
-                [css.selected]: selected,
+                [css.selected]: index === selectedVersion,
               })}
             >
               {name}

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import classNames from 'classnames';
@@ -44,6 +44,33 @@ export const RoadmapGraphPage = () => {
     chosenRoadmapSelector,
     shallowEqual,
   );
+
+  // TODO: scrolling selected into view from BlockGraph doesn't work with this
+  const a = useRef<HTMLDivElement>(null);
+  const b = useRef<HTMLDivElement>(null);
+  const refs = useRef([a, b]);
+  const scrolling = useRef(0);
+
+  useEffect(() => {
+    const handleScroll = (e: any) => {
+      if (scrolling.current) {
+        scrolling.current = 0;
+        return;
+      }
+
+      scrolling.current = 1;
+      const other = e.target === a.current ? b : a;
+
+      window.requestAnimationFrame(() =>
+        other.current?.scroll({ left: e.target.scrollLeft }),
+      );
+    };
+
+    const elements = [a.current, b.current];
+    elements.forEach((el) => el?.addEventListener('scroll', handleScroll));
+    return () =>
+      elements.forEach((el) => el?.removeEventListener('scroll', handleScroll));
+  }, [refs, scrolling]);
 
   useEffect(() => {
     if (!currentRoadmap) dispatch(roadmapsActions.getRoadmaps());
@@ -99,6 +126,7 @@ export const RoadmapGraphPage = () => {
         id={(ver) => ver.id}
         dimensions={dimensions}
         limits={limits}
+        innerRef={a}
       >
         {({ item: { name, value, work, tasks }, selected }) => (
           <>
@@ -143,6 +171,7 @@ export const RoadmapGraphPage = () => {
             items={versions ?? []}
             dimensions={dimensions}
             limits={limits}
+            innerRef={b}
           >
             {({ item: ver, width }) => (
               <TaskValueCreatedVisualization

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -45,8 +45,7 @@ export const RoadmapGraphPage = () => {
     shallowEqual,
   );
 
-  // TODO: scrolling selected into view from BlockGraph doesn't work with this
-  const a = useRef<HTMLDivElement>(null);
+  const a = useRef<HTMLDivElement | null>(null);
   const b = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -115,7 +114,9 @@ export const RoadmapGraphPage = () => {
         id={(ver) => ver.id}
         dimensions={dimensions}
         limits={limits}
-        innerRef={a}
+        innerRef={(e) => {
+          a.current = e;
+        }}
       >
         {({ item: { name, value, work, tasks }, index }) => (
           <>

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -12,6 +12,7 @@ import { TaskValueCreatedVisualization } from '../components/TaskValueCreatedVis
 import { InfoTooltip } from '../components/InfoTooltip';
 import css from './RoadmapGraphPage.module.scss';
 import { BusinessIcon, WorkRoundIcon } from '../components/RoleIcons';
+import { BlockGraph, BlockView } from '../components/BlockGraph';
 import {
   chosenRoadmapSelector,
   roadmapsVersionsSelector,
@@ -35,9 +36,7 @@ export const RoadmapGraphPage = () => {
     roadmapsVersionsSelector(),
     shallowEqual,
   );
-  const [selectedVersion, setSelectedVersion] = useState<undefined | Version>(
-    undefined,
-  );
+  const [selectedVersion, setSelectedVersion] = useState(-1);
   const [versions, setVersions] = useState<undefined | VersionWorkAndValues[]>(
     undefined,
   );
@@ -61,13 +60,7 @@ export const RoadmapGraphPage = () => {
   }, [currentRoadmap, roadmapsVersions]);
 
   useEffect(() => {
-    if (
-      selectedVersion === undefined &&
-      roadmapsVersions &&
-      roadmapsVersions[0]
-    ) {
-      setSelectedVersion(roadmapsVersions[0]);
-    }
+    if (selectedVersion < 0 && roadmapsVersions?.length) setSelectedVersion(0);
   }, [roadmapsVersions, selectedVersion]);
 
   const numFormat = new Intl.NumberFormat(undefined, {
@@ -75,65 +68,65 @@ export const RoadmapGraphPage = () => {
     maximumFractionDigits: 1,
   });
 
+  const dimensions = ({ work, value }: VersionWorkAndValues) => ({
+    width: work,
+    height: value,
+  });
+
+  const limits = {
+    minWidth: 100,
+    maxWidth: 300,
+    minHeight: 100,
+    maxHeight: 300,
+  };
+
   return (
     <div className={classes(css.plannerPagecontainer)}>
-      <div className={classes(css.graphOuter)}>
-        <div className={classes(css.titleContainer)}>
-          <h2 className={classes(css.graphTitle)}>{t('workValueTitle')}</h2>
-          <InfoTooltip title={t('tooltipMessage')}>
-            <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
-          </InfoTooltip>
-        </div>
-
-        <div className={classes(css.graphInner)}>
-          <div className={classes(css.graphItems)}>
-            {versions?.map((ver) => {
-              const numTasks = ver.tasks.length;
-              const w = Math.max(100, 60 * (ver.work / 5));
-              const h = Math.min(350, Math.max(100, 45 * Math.log2(ver.value)));
-              return (
-                <div
-                  className={classes(css.graphItem, {
-                    [css.selected]: ver.id === selectedVersion?.id,
-                  })}
-                  style={{ width: `${w}px`, height: `${h}px` }}
-                  key={ver.id}
-                  onClick={() => setSelectedVersion(ver)}
-                  onKeyPress={() => setSelectedVersion(ver)}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <div className={classes(css.versionData)}>
-                    <div className={classes(css.ratingDiv)}>
-                      <BusinessIcon size="xxsmall" color={colors.azure} />
-                      <p>{numFormat.format(ver.value)}</p>
-                    </div>
-                    <div className={classes(css.ratingDiv)}>
-                      <WorkRoundIcon size="xxsmall" color={colors.azure} />
-                      <p>{numFormat.format(ver.work)}</p>
-                    </div>
-                    <div className={classes(css.dash)} />
-                    <div className={classes(css.ratingDiv)}>
-                      <ListIcon />
-                      <p>{numTasks}</p>
-                    </div>
-                  </div>
-                  <p
-                    className={classes(css.versionTitle, {
-                      [css.selected]: ver.id === selectedVersion?.id,
-                    })}
-                  >
-                    {ver.name}
-                  </p>
-                </div>
-              );
-            })}
+      <BlockGraph
+        title={
+          <div className={classes(css.titleContainer)}>
+            <h2 className={classes(css.graphTitle)}>{t('workValueTitle')}</h2>
+            <InfoTooltip title={t('tooltipMessage')}>
+              <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
+            </InfoTooltip>
           </div>
-        </div>
-        <p className={classes(css.graphLabel)}>Total work</p>
-      </div>
-      <p className={classes(css.graphLabel, css.vertical)}>Total value</p>
-
+        }
+        xLabel="Total work"
+        yLabel="Total value"
+        selected={selectedVersion}
+        setSelected={setSelectedVersion}
+        items={versions ?? []}
+        id={(ver) => ver.id}
+        dimensions={dimensions}
+        limits={limits}
+      >
+        {({ item: { name, value, work, tasks }, selected }) => (
+          <>
+            <div className={classes(css.versionData)}>
+              <div className={classes(css.ratingDiv)}>
+                <BusinessIcon size="xxsmall" color={colors.azure} />
+                <p>{numFormat.format(value)}</p>
+              </div>
+              <div className={classes(css.ratingDiv)}>
+                <WorkRoundIcon size="xxsmall" color={colors.azure} />
+                <p>{numFormat.format(work)}</p>
+              </div>
+              <div className={classes(css.dash)} />
+              <div className={classes(css.ratingDiv)}>
+                <ListIcon />
+                <p>{tasks.length}</p>
+              </div>
+            </div>
+            <p
+              className={classes(css.versionTitle, {
+                [css.selected]: selected,
+              })}
+            >
+              {name}
+            </p>
+          </>
+        )}
+      </BlockGraph>
       <div className={classes(css.footer)}>
         <div
           className={classes(css.titleContainer, css.lowerGraphTitleContainer)}
@@ -146,9 +139,19 @@ export const RoadmapGraphPage = () => {
           </InfoTooltip>
         </div>
         <div className={classes(css.stakesContainer)}>
-          {versions?.map((ver) => (
-            <TaskValueCreatedVisualization version={ver} key={ver.id} />
-          ))}
+          <BlockView
+            items={versions ?? []}
+            dimensions={dimensions}
+            limits={limits}
+          >
+            {({ item: ver, width }) => (
+              <TaskValueCreatedVisualization
+                width={width}
+                version={ver}
+                key={ver.id}
+              />
+            )}
+          </BlockView>
         </div>
       </div>
     </div>


### PR DESCRIPTION
At the moment this scrolls the selected element into view, but that does not work when synchronising the two views on /planner/graph page. Well, it would without 'smooth' scroll, but then it doesn't feel nice.