### PR TITLE
Add functionality for removing task relations through task-map

### DIFF
--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -23,6 +23,7 @@ import {
   GetRoadmapBoardLabelsRequest,
   Version,
   VersionRequest,
+  TaskRelation,
 } from '../redux/roadmaps/types';
 import { IntegrationBoard, Integrations } from '../redux/types';
 import {
@@ -366,6 +367,17 @@ const addTaskRelation = async (relation: TaskRelationRequest) => {
   return response.status === 200;
 };
 
+const removeTaskRelation = async (
+  roadmapId: number,
+  relation: TaskRelation,
+) => {
+  const response = await axios.delete(
+    `/roadmaps/${roadmapId}/tasks/relations`,
+    { data: relation },
+  );
+  return response.status === 200;
+};
+
 export const api = {
   getRoadmaps,
   addRoadmap,
@@ -409,4 +421,5 @@ export const api = {
   verifyEmail,
   sendEmailVerificationLink,
   addTaskRelation,
+  removeTaskRelation,
 };

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -204,6 +204,7 @@ export const TaskMapPage = () => {
           custom: CustomEdge,
         }}
         elementsSelectable={false}
+        onContextMenu={(e) => e.preventDefault()}
       >
         <Controls showInteractive={false} showZoom={false}>
           <InfoTooltip title={t('Taskmap-tooltip')}>

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -23,6 +23,7 @@ import {
   RemoveTaskFromVersionRequest,
   Version,
   VersionRequest,
+  TaskRelation,
 } from './types';
 import { RoleType } from '../../../../shared/types/customTypes';
 
@@ -530,5 +531,20 @@ export const addTaskRelation = createAsyncThunk<
     return await api.addTaskRelation(relationRequest);
   } catch (err) {
     return thunkAPI.rejectWithValue(err);
+  }
+});
+
+export const removeTaskRelation = createAsyncThunk<
+  boolean,
+  TaskRelation,
+  { rejectValue: AxiosError }
+>('removeTaskRelation', async (relationRequest, thunkAPI) => {
+  try {
+    const roadmapId = chosenRoadmapIdSelector(
+      thunkAPI.getState() as RootState,
+    )!;
+    return await api.removeTaskRelation(roadmapId, relationRequest);
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err as AxiosError<any>);
   }
 });

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -29,6 +29,7 @@ import {
   notifyUsers,
   sendInvitation,
   addTaskRelation,
+  removeTaskRelation,
 } from './actions';
 import {
   ADD_ROADMAP_FULFILLED,
@@ -134,4 +135,5 @@ export const roadmapsActions = {
   notifyUsers,
   sendInvitation,
   addTaskRelation,
+  removeTaskRelation,
 };


### PR DESCRIPTION
First version of relation deleting. Currently there's two ways to delete a relation: right clicking an edge or hovering over it and pressing backspace or delete.

There will be additional features added to deleting relations but this is enough currently. The rest of the features will be added after automatic layout generator has been implemented, that will give us more info how things should work.