### PR TITLE
Retain edited text on error

### DIFF
--- a/frontend/src/components/EditableText.tsx
+++ b/frontend/src/components/EditableText.tsx
@@ -37,8 +37,8 @@ const withButtons = (Component: typeof EditableText) => ({
         if (returnedError) setErrorMessage(returnedError);
         else {
           setEditOpen(false);
+          setEditText('');
         }
-        setEditText('');
         setIsLoading(false);
       });
     } else {
@@ -47,9 +47,11 @@ const withButtons = (Component: typeof EditableText) => ({
   };
 
   const handleCancel = () => {
-    setErrorMessage('');
-    setEditText('');
-    setEditOpen(false);
+    if (errorMessage) setErrorMessage('');
+    else {
+      setEditText('');
+      setEditOpen(false);
+    }
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/Overview.module.scss
+++ b/frontend/src/components/Overview.module.scss
@@ -49,6 +49,7 @@
 .data {
   @extend .layout-row;
   flex: 1;
+  gap: 10px;
   .column {
     @extend .layout-column;
     align-items: center;


### PR DESCRIPTION
- When there is an error the `cancel` button only clears the error
  message and does not close the edit field
- The text is only cleared after successful submit

Alternative for #196