### PR TITLE
Fix bug with EditableText not closing on task change

### DIFF
--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -123,6 +123,7 @@ const TaskOverview: FC<{
         metrics={metrics}
         data={taskData}
         onDataEditConfirm={handleEditConfirm}
+        key={task.id}
       />
       <div className={classes(css.ratings)}>
         {valueRatings.length > 0 && (


### PR DESCRIPTION
The fix was implemented earlier, but it got lost in the rebase.