### PR TITLE
Few fixes

### DIFF
--- a/frontend/src/components/CustomerListTable.tsx
+++ b/frontend/src/components/CustomerListTable.tsx
@@ -86,7 +86,7 @@ export const CustomerList: FC<{
             sorting: CustomerSortingTypes.SORT_UNRATED,
             width: '0.5fr',
           },
-          ...(role === RoleType.Admin ? [{ label: '' }] : []),
+          { label: '', width: role === RoleType.Admin ? '1fr' : '0.5fr' },
         ],
       }),
     [currentRoadmap, role],

--- a/frontend/src/components/RatingTableValue.tsx
+++ b/frontend/src/components/RatingTableValue.tsx
@@ -14,8 +14,9 @@ const numFormat = new Intl.NumberFormat(undefined, {
 });
 
 const TableValueRatingRow: RatingRow = ({ rating, style }) => {
-  const user = useSelector(userSelector(rating.createdByUser))!;
-  const customer = useSelector(customerSelector(rating.forCustomer))!;
+  const user = useSelector(userSelector(rating.createdByUser));
+  const customer = useSelector(customerSelector(rating.forCustomer));
+  if (!user || !customer) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>

--- a/frontend/src/components/RatingTableWork.tsx
+++ b/frontend/src/components/RatingTableWork.tsx
@@ -14,7 +14,8 @@ const numFormat = new Intl.NumberFormat(undefined, {
 });
 
 const TableWorkRatingRow: RatingRow = ({ rating, style }) => {
-  const user = useSelector(userSelector(rating.createdByUser))!;
+  const user = useSelector(userSelector(rating.createdByUser));
+  if (!user) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>

--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -11,28 +11,15 @@ import { paths } from '../routers/paths';
 import { ReactComponent as DashboardIcon } from '../icons/dashboard_icon.svg';
 import { ReactComponent as VisdomLogo } from '../icons/visdom_icon.svg';
 import css from './RoadmapSidebar.module.scss';
-import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
-import { Roadmap } from '../redux/roadmaps/types';
-import { RootState } from '../redux/types';
-import { userInfoSelector } from '../redux/user/selectors';
-import { UserInfo } from '../redux/user/types';
+import { userRoleSelector } from '../redux/user/selectors';
 import { RoleType } from '../../../shared/types/customTypes';
-import { getType } from '../utils/UserUtils';
 
 const classes = classNames.bind(css);
 
 export const RoadmapSidebar: FC = () => {
   const { url } = useRouteMatch();
   const { pathname } = useLocation();
-  const userInfo = useSelector<RootState, UserInfo | undefined>(
-    userInfoSelector,
-    shallowEqual,
-  );
-  const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
-    chosenRoadmapSelector,
-    shallowEqual,
-  );
-  const role = getType(userInfo, currentRoadmap?.id);
+  const role = useSelector(userRoleSelector, shallowEqual);
 
   if (!url.startsWith('/roadmap')) return null;
 

--- a/frontend/src/components/TaskRatingWidget.tsx
+++ b/frontend/src/components/TaskRatingWidget.tsx
@@ -7,13 +7,8 @@ import {
   TaskRatingDimension,
   RoleType,
 } from '../../../shared/types/customTypes';
-import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
-import { Roadmap } from '../redux/roadmaps/types';
-import { RootState } from '../redux/types';
-import { userInfoSelector } from '../redux/user/selectors';
-import { UserInfo } from '../redux/user/types';
+import { userRoleSelector } from '../redux/user/selectors';
 import { TaskRatingBar } from './RatingBars';
-import { getType } from '../utils/UserUtils';
 import { TextArea } from './forms/FormField';
 import css from './TaskRatingWidget.module.scss';
 
@@ -39,15 +34,7 @@ export const TaskRatingWidget: FC<TaskRatingWidgetProps> = ({
   name,
 }) => {
   const { t } = useTranslation();
-  const userInfo = useSelector<RootState, UserInfo | undefined>(
-    userInfoSelector,
-    shallowEqual,
-  );
-  const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
-    chosenRoadmapSelector,
-    shallowEqual,
-  );
-  const role = getType(userInfo, currentRoadmap?.id);
+  const role = useSelector(userRoleSelector, shallowEqual);
   const [rating, setRating] = useState(
     initialRating || {
       value: 0,

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -3,13 +3,8 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 import { Search } from 'react-bootstrap-icons';
-import { Roadmap } from '../redux/roadmaps/types';
-import { RootState } from '../redux/types';
-import { userInfoSelector } from '../redux/user/selectors';
-import { UserInfo } from '../redux/user/types';
+import { userRoleSelector } from '../redux/user/selectors';
 import { RoleType } from '../../../shared/types/customTypes';
-import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
-import { getType } from '../utils/UserUtils';
 import css from './TopBar.module.scss';
 
 const classes = classNames.bind(css);
@@ -21,14 +16,7 @@ export const TopBar: FC<{
   onAddClick: (e: MouseEvent) => void;
 }> = ({ searchType, addType, onSearchChange, onAddClick, children }) => {
   const { t } = useTranslation();
-  const userInfo = useSelector<RootState, UserInfo | undefined>(
-    userInfoSelector,
-    shallowEqual,
-  );
-  const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
-    chosenRoadmapSelector,
-    shallowEqual,
-  );
+  const role = useSelector(userRoleSelector, shallowEqual);
 
   return (
     <div className="topBar">
@@ -42,7 +30,7 @@ export const TopBar: FC<{
       </div>
       {children}
       <div className={classes(css.rightSide)}>
-        {getType(userInfo, currentRoadmap?.id) === RoleType.Admin && (
+        {role === RoleType.Admin && (
           <button
             className="button-small-filled"
             type="button"

--- a/frontend/src/pages/ClientsListPage.tsx
+++ b/frontend/src/pages/ClientsListPage.tsx
@@ -5,27 +5,14 @@ import { CustomerList } from '../components/CustomerListTable';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from '../components/modals/types';
 import { StoreDispatchType } from '../redux/index';
-import { RootState } from '../redux/types';
-import { chosenRoadmapSelector } from '../redux/roadmaps/selectors';
-import { Roadmap } from '../redux/roadmaps/types';
-import { userInfoSelector } from '../redux/user/selectors';
-import { UserInfo } from '../redux/user/types';
-import { getType } from '../utils/UserUtils';
+import { userRoleSelector } from '../redux/user/selectors';
 import { TopBar } from '../components/TopBar';
 
 export const ClientsListPage = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch<StoreDispatchType>();
   const [searchString, setSearchString] = useState('');
-  const userInfo = useSelector<RootState, UserInfo | undefined>(
-    userInfoSelector,
-    shallowEqual,
-  );
-  const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
-    chosenRoadmapSelector,
-    shallowEqual,
-  );
-  const role = getType(userInfo, currentRoadmap?.id);
+  const role = useSelector(userRoleSelector, shallowEqual);
 
   const addCustomerClicked = (e: MouseEvent) => {
     e.preventDefault();

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -3,9 +3,11 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { useParams, useHistory, Redirect } from 'react-router-dom';
+import { Permission } from '../../../shared/types/customTypes';
 import { roadmapsActions } from '../redux/roadmaps';
 import { StoreDispatchType } from '../redux/index';
 import { valueAndWorkSummary, getRatingsByType } from '../utils/TaskUtils';
+import { hasPermission } from '../utils/UserUtils';
 import { BusinessIcon, WorkRoundIcon } from '../components/RoleIcons';
 import { allTasksSelector } from '../redux/roadmaps/selectors';
 import { Task, TaskRequest } from '../redux/roadmaps/types';
@@ -34,9 +36,9 @@ const TaskOverview: FC<{
   const { roadmapId } = useParams<{
     roadmapId: string | undefined;
   }>();
-  const { value, work } = valueAndWorkSummary(task!);
+  const { value, work } = valueAndWorkSummary(task);
   const { value: valueRatings, work: workRatings } = getRatingsByType(
-    task?.ratings || [],
+    task.ratings,
   );
   const tasksListPage = `${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.taskList}`;
 
@@ -125,14 +127,16 @@ const TaskOverview: FC<{
         onDataEditConfirm={handleEditConfirm}
         key={task.id}
       />
-      <div className={classes(css.ratings)}>
-        {valueRatings.length > 0 && (
-          <RatingTableValue ratings={valueRatings} avg={value.avg} />
-        )}
-        {workRatings.length > 0 && (
-          <RatingTableWork ratings={workRatings} avg={work.avg} />
-        )}
-      </div>
+      {hasPermission(role, Permission.RoadmapReadUsers) && (
+        <div className={classes(css.ratings)}>
+          {valueRatings.length > 0 && (
+            <RatingTableValue ratings={valueRatings} avg={value.avg} />
+          )}
+          {workRatings.length > 0 && (
+            <RatingTableWork ratings={workRatings} avg={work.avg} />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -10,6 +10,7 @@ import { valueAndWorkSummary, getRatingsByType } from '../utils/TaskUtils';
 import { hasPermission } from '../utils/UserUtils';
 import { BusinessIcon, WorkRoundIcon } from '../components/RoleIcons';
 import { allTasksSelector } from '../redux/roadmaps/selectors';
+import { userRoleSelector } from '../redux/user/selectors';
 import { Task, TaskRequest } from '../redux/roadmaps/types';
 import { paths } from '../routers/paths';
 import { RatingTableWork } from '../components/RatingTableWork';
@@ -33,6 +34,7 @@ const TaskOverview: FC<{
   const history = useHistory();
   const { t } = useTranslation();
   const dispatch = useDispatch<StoreDispatchType>();
+  const role = useSelector(userRoleSelector, shallowEqual);
   const { roadmapId } = useParams<{
     roadmapId: string | undefined;
   }>();
@@ -73,13 +75,13 @@ const TaskOverview: FC<{
         keyName: 'name',
         value: task.name,
         format: 'bold',
-        editable: true,
+        editable: hasPermission(role, Permission.TaskEdit),
       },
       {
         label: t('Description'),
         keyName: 'description',
         value: task.description,
-        editable: true,
+        editable: hasPermission(role, Permission.TaskEdit),
       },
     ],
     [

--- a/frontend/src/redux/user/selectors.ts
+++ b/frontend/src/redux/user/selectors.ts
@@ -1,5 +1,13 @@
+import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../types';
 import { UserInfo } from './types';
+import { getType } from '../../utils/UserUtils';
 
 export const userInfoSelector = (state: RootState): UserInfo | undefined =>
   state.user.info;
+
+export const userRoleSelector = createSelector(
+  (state: RootState) => state.user.info?.roles,
+  (state) => state.roadmaps.selectedRoadmapId,
+  getType,
+);


### PR DESCRIPTION
Fixed the crash on task overview by removing the individual rating listing.

Also disabled task editing in the task overview page for others than admin, since it would fail on the backend anyway.

Added the role selector since there were quite a few places using `currentRoadmap` and `userInfo` selectors just to get the role.