### PR TITLE
Save taskmap's position

### DIFF
--- a/frontend/src/components/RoadmapSelectorWidget.tsx
+++ b/frontend/src/components/RoadmapSelectorWidget.tsx
@@ -66,6 +66,7 @@ export const RoadmapSelectorWidget = () => {
         <Link
           key={roadmap.id}
           className={classes(css.dropItem)}
+          onClick={() => dispatch(roadmapsActions.clearTaskmapPosition())}
           to={`${paths.roadmapHome}/${roadmap.id}${paths.roadmapRelative.dashboard}`}
         >
           {roadmap.name}

--- a/frontend/src/pages/ProjectOverviewPage.tsx
+++ b/frontend/src/pages/ProjectOverviewPage.tsx
@@ -29,6 +29,7 @@ const ProjectOverviewComponent = () => {
 
   useEffect(() => {
     dispatch(roadmapsActions.clearCurrentRoadmap());
+    dispatch(roadmapsActions.clearTaskmapPosition());
   }, [dispatch]);
 
   const addRoadmapClicked = (e: MouseEvent) => {

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -1,6 +1,10 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
-import ReactFlow, { Handle, Controls } from 'react-flow-renderer';
+import ReactFlow, {
+  Handle,
+  Controls,
+  useStoreState,
+} from 'react-flow-renderer';
 import classNames from 'classnames';
 import DoneAllIcon from '@material-ui/icons/DoneAll';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
@@ -10,6 +14,7 @@ import {
   allTasksSelector,
   chosenRoadmapSelector,
   taskSelector,
+  taskmapPositionSelector,
 } from '../redux/roadmaps/selectors';
 import { roadmapsActions } from '../redux/roadmaps';
 import { Roadmap, Task, TaskRelation } from '../redux/roadmaps/types';
@@ -119,6 +124,23 @@ const TaskComponent: FC<{
   );
 };
 
+const ReactFlowState = () => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const pos = useStoreState((state) => state.transform);
+
+  useEffect(() => {
+    dispatch(
+      roadmapsActions.setTaskmapPosition({
+        x: pos[0],
+        y: pos[1],
+        zoom: pos[2],
+      }),
+    );
+  }, [dispatch, pos]);
+
+  return null;
+};
+
 const CustomNodeComponent: FC<{ data: any }> = ({ data }) => {
   return <div>{data.label}</div>;
 };
@@ -126,6 +148,7 @@ const CustomNodeComponent: FC<{ data: any }> = ({ data }) => {
 export const TaskMapPage = () => {
   const { t } = useTranslation();
   const tasks = useSelector(allTasksSelector(), shallowEqual);
+  const mapPosition = useSelector(taskmapPositionSelector, shallowEqual);
   const dispatch = useDispatch<StoreDispatchType>();
   const taskRelations = groupTaskRelations(tasks);
   const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
@@ -205,7 +228,10 @@ export const TaskMapPage = () => {
         }}
         elementsSelectable={false}
         onContextMenu={(e) => e.preventDefault()}
+        defaultZoom={mapPosition?.zoom}
+        defaultPosition={mapPosition && [mapPosition.x, mapPosition.y]}
       >
+        <ReactFlowState />
         <Controls showInteractive={false} showZoom={false}>
           <InfoTooltip title={t('Taskmap-tooltip')}>
             <InfoIcon

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -56,12 +56,15 @@ import {
   GET_VERSIONS_FULFILLED,
   PATCH_VERSION_FULFILLED,
   DELETE_VERSION_FULFILLED,
+  SET_TASKMAP_POSITION,
+  CLEAR_TASKMAP_POSITION,
 } from './reducers';
 import { RoadmapsState } from './types';
 
 const initialState: RoadmapsState = {
   roadmaps: undefined,
   selectedRoadmapId: undefined,
+  taskmapPosition: undefined,
 };
 
 export const roadmapsSlice = createSlice({
@@ -70,6 +73,8 @@ export const roadmapsSlice = createSlice({
   reducers: {
     selectCurrentRoadmap: SELECT_CURRENT_ROADMAP,
     clearCurrentRoadmap: CLEAR_CURRENT_ROADMAP,
+    setTaskmapPosition: SET_TASKMAP_POSITION,
+    clearTaskmapPosition: CLEAR_TASKMAP_POSITION,
   },
   extraReducers: (builder) => {
     builder.addCase(getRoadmaps.fulfilled, GET_ROADMAPS_FULFILLED);

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -14,6 +14,7 @@ import {
   TaskratingRequest,
   TaskRequest,
   Version,
+  TaskmapPosition,
 } from './types';
 
 export const GET_ROADMAPS_FULFILLED = (
@@ -303,4 +304,15 @@ export const DELETE_VERSION_FULFILLED = (
     ({ id }) => id === action.payload.roadmapId,
   )!;
   roadmap.versions = action.payload.response;
+};
+
+export const SET_TASKMAP_POSITION: CaseReducer<
+  RoadmapsState,
+  PayloadAction<TaskmapPosition>
+> = (state, action) => {
+  state.taskmapPosition = action.payload;
+};
+
+export const CLEAR_TASKMAP_POSITION: CaseReducer<RoadmapsState> = (state) => {
+  state.taskmapPosition = undefined;
 };

--- a/frontend/src/redux/roadmaps/selectors.ts
+++ b/frontend/src/redux/roadmaps/selectors.ts
@@ -78,3 +78,6 @@ export const roadmapsVersionsSelector = (roadmapId?: number) =>
       );
     },
   );
+
+export const taskmapPositionSelector = (state: RootState) =>
+  state.roadmaps.taskmapPosition;

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -7,6 +7,7 @@ import {
 export interface RoadmapsState {
   roadmaps: Roadmap[] | undefined;
   selectedRoadmapId?: number;
+  taskmapPosition: TaskmapPosition | undefined;
 }
 
 export interface Customer {
@@ -202,4 +203,10 @@ export interface AddTaskToVersionRequest {
 export interface RemoveTaskFromVersionRequest {
   task: TaskRequest;
   version: VersionRequest;
+}
+
+export interface TaskmapPosition {
+  zoom: number;
+  x: number;
+  y: number;
 }


### PR DESCRIPTION
Position (x, y -coordinates and zoom level) is saved to redux.

Taskmap's position is cleared when project overview is opened or roadmap is selected from the dropdown
- clearing the position on SELECT_CURRENT_ROADMAP was not suitable as it is run in every reload