### PR TITLE
Fix import modal dropdown

### DIFF
--- a/frontend/src/components/TopBar.module.scss
+++ b/frontend/src/components/TopBar.module.scss
@@ -2,4 +2,5 @@
 
 .rightSide {
   margin-left: auto;
+  padding-left: 10px;
 }

--- a/frontend/src/components/modals/ImportTasksModal.tsx
+++ b/frontend/src/components/modals/ImportTasksModal.tsx
@@ -174,6 +174,7 @@ export const ImportTasksModal: Modal<ModalTypes.IMPORT_TASKS_MODAL> = ({
           className="react-select"
           placeholder="No boards available"
           isDisabled={boards.length === 0}
+          menuPortalTarget={document.body}
           onChange={(selected) =>
             selected && setSelectedBoardId(selected.value)
           }
@@ -201,6 +202,7 @@ export const ImportTasksModal: Modal<ModalTypes.IMPORT_TASKS_MODAL> = ({
           isMulti
           isClearable
           isDisabled={selectedBoardId === undefined}
+          menuPortalTarget={document.body}
           onChange={(selected) =>
             setSelectedLabels(
               new Map(selectedLabels).set(


### PR DESCRIPTION
Didn't find a way to grow the modal conveniently to fit the opened list. However, attaching the list to the document body instead of the modal allows it to go over the boundaries of the modal window such that it is visible and usable.

Also small visual fix on the task page top bar buttons.