### PR TITLE
Fix task relations type

### DIFF
--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -88,7 +88,7 @@ export interface Task {
   createdAt: string;
   completed: boolean;
   ratings: Taskrating[];
-  relations: TaskRelation[];
+  relations?: TaskRelation[];
   createdByUser: number;
 }
 

--- a/frontend/src/utils/TaskRelationUtils.ts
+++ b/frontend/src/utils/TaskRelationUtils.ts
@@ -22,7 +22,7 @@ export const groupTaskRelations = (tasks: Task[]) => {
       dependencies: [],
     };
 
-    relations.forEach(({ from, to, type }) => {
+    relations?.forEach(({ from, to, type }) => {
       if (type === TaskRelationType.Synergy) subgroup.synergies.push(to);
       if (type === TaskRelationType.Dependency)
         subgroup.dependencies.push({ from, to });


### PR DESCRIPTION
bugfix: https://trello.com/c/zbLbvSlK/369-task-map-hajoaa-jos-lis%C3%A4%C3%A4t-task-tablesta-uuden-taskin-ja-sitten-avaat-task-map-v%C3%A4lilehden

- Relations can be undefined