### PR TITLE
Make sidebar buttons scrollable

### DIFF
--- a/frontend/src/components/RoadmapSidebar.module.scss
+++ b/frontend/src/components/RoadmapSidebar.module.scss
@@ -7,8 +7,10 @@
 
 .buttonsContainer {
   @extend .layout-column;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: 100%;
+
+  @extend .hide-scrollbar;
 }
 
 .navButton {

--- a/frontend/src/components/RoadmapSidebar.module.scss
+++ b/frontend/src/components/RoadmapSidebar.module.scss
@@ -1,5 +1,16 @@
 @import './../shared.scss';
 
+.container {
+  @extend .layout-column;
+  height: 100vh;
+}
+
+.buttonsContainer {
+  @extend .layout-column;
+  overflow-y: scroll;
+  height: 100%;
+}
+
 .navButton {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -107,13 +107,13 @@ export const RoadmapSidebar: FC = () => {
   };
 
   return (
-    <div className={classes('layout-column')}>
+    <div className={classes(css.container)}>
       <div className={classes(css.navButton, css.logo)}>
         <Link to={paths.overview} className={classes(css.visdomLogo)}>
           <VisdomLogo />
         </Link>
       </div>
-      {renderButtons()}
+      <div className={classes(css.buttonsContainer)}>{renderButtons()}</div>
     </div>
   );
 };

--- a/frontend/src/components/modals/AddRoadmapModal.module.scss
+++ b/frontend/src/components/modals/AddRoadmapModal.module.scss
@@ -13,12 +13,11 @@
   min-height: 390px;
   padding: 20px;
 
-  // hide member list scrollbar
-  @extend .hide-scrollbar;
-
   .members {
     overflow: auto;
     height: 300px;
+    // hide member list scrollbar
+    @extend .hide-scrollbar;
   }
 
   .addMemberButton {

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -32,7 +32,7 @@
 }
 
 .hide-scrollbar {
-  ::-webkit-scrollbar {
+  &::-webkit-scrollbar {
     display: none;
   }
   -ms-overflow-style: none;


### PR DESCRIPTION
Previously the buttons would stretch the page vertically beyond the
viewport height, which would add extra scrollbars to the page and make
the scrolling overall a bad experience.