### PR TITLE
Invitation flow

### DIFF
--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -326,6 +326,11 @@ const getInvitations = async (roadmapId: number) => {
   return response.data as Invitation[];
 };
 
+const getInvitation = async (invitationId: string) => {
+  const response = await axios.get(`users/join/${invitationId}`);
+  return response.data as Invitation;
+};
+
 const sendInvitation = async (
   email: string,
   type: RoleType,
@@ -419,6 +424,7 @@ export const api = {
   sendNotification,
   patchDefaultRoadmap,
   getInvitations,
+  getInvitation,
   sendInvitation,
   patchInvitation,
   deleteInvitation,

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -21,7 +21,8 @@ export const NavBar = () => {
   return (
     <div className={classes(css.navBarDiv)}>
       <CornerPiece />
-      {pathname.startsWith(paths.overview) && (
+      {(pathname.startsWith(paths.overview) ||
+        pathname.startsWith('/join')) && (
         <div className={classes(css.logo)}>
           <VisdomLogo />
         </div>

--- a/frontend/src/components/forms/StepForm.tsx
+++ b/frontend/src/components/forms/StepForm.tsx
@@ -16,7 +16,7 @@ const classes = classNames.bind(css);
 
 interface Step {
   component: FC;
-  description: string;
+  description?: string;
   disabled?: () => boolean;
   noCancelConfirmation?: () => boolean;
 }
@@ -113,17 +113,20 @@ export const StepForm: FC<{
       <>
         {steps.length > 1 && (
           <div className={classes(css.steps)}>
-            {steps.map(({ description }, i) => (
-              <StepIndicator
-                currentStep={step}
-                step={i + 1}
-                maxStep={steps.length}
-                // eslint-disable-next-line
-                key={i + 1}
-                description={description}
-                onClick={() => setStep(i + 1)}
-              />
-            ))}
+            {steps.map(({ description }, i) => {
+              if (!description) return null;
+              return (
+                <StepIndicator
+                  currentStep={step}
+                  step={i + 1}
+                  maxStep={steps.length}
+                  // eslint-disable-next-line
+                  key={i + 1}
+                  description={description}
+                  onClick={() => setStep(i + 1)}
+                />
+              );
+            })}
           </div>
         )}
         {steps[step - 1].component({})}

--- a/frontend/src/components/modals/JoinLinkInvalidModal.tsx
+++ b/frontend/src/components/modals/JoinLinkInvalidModal.tsx
@@ -1,0 +1,55 @@
+import { FormEvent } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Form } from 'react-bootstrap';
+import { Trans } from 'react-i18next';
+import { Modal, ModalTypes } from './types';
+import { ModalContent } from './modalparts/ModalContent';
+import { ModalFooter } from './modalparts/ModalFooter';
+import { ModalFooterButtonDiv } from './modalparts/ModalFooterButtonDiv';
+import { ModalHeader } from './modalparts/ModalHeader';
+import { paths } from '../../routers/paths';
+import { ReactComponent as AlertOrangeIcon } from '../../icons/alert_orange_icon.svg';
+import '../../shared.scss';
+
+export const JoinLinkInvalidModal: Modal<ModalTypes.JOIN_LINK_INVALID_MODAL> = ({
+  closeModal,
+}) => {
+  const history = useHistory();
+
+  const closeAndRedirectToOverview = () => {
+    closeModal();
+    history.push(`${paths.overview}`);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    closeAndRedirectToOverview();
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <ModalHeader closeModal={closeAndRedirectToOverview}>
+        <h3>
+          <Trans i18nKey="Project link invalid" />
+        </h3>
+      </ModalHeader>
+      <ModalContent>
+        <div className="modalCancelContent">
+          <AlertOrangeIcon />
+          <div>
+            <Trans i18nKey="Project link invalid info 1/2" />
+          </div>
+          <Trans i18nKey="Project link invalid info 2/2" />
+        </div>
+      </ModalContent>
+      <ModalFooter>
+        <ModalFooterButtonDiv>
+          <button className="button-large" type="submit">
+            <Trans i18nKey="OK!" />
+          </button>
+        </ModalFooterButtonDiv>
+      </ModalFooter>
+    </Form>
+  );
+};

--- a/frontend/src/components/modals/JoinLinkNoAccessModal.tsx
+++ b/frontend/src/components/modals/JoinLinkNoAccessModal.tsx
@@ -1,0 +1,70 @@
+import { FormEvent } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Form } from 'react-bootstrap';
+import { Trans } from 'react-i18next';
+import { Modal, ModalTypes } from './types';
+import { ModalContent } from './modalparts/ModalContent';
+import { ModalFooter } from './modalparts/ModalFooter';
+import { ModalFooterButtonDiv } from './modalparts/ModalFooterButtonDiv';
+import { ModalHeader } from './modalparts/ModalHeader';
+import { paths } from '../../routers/paths';
+import { ReactComponent as AlertOrangeIcon } from '../../icons/alert_orange_icon.svg';
+import '../../shared.scss';
+
+export const JoinLinkNoAccessModal: Modal<ModalTypes.JOIN_LINK_NO_ACCESS_MODAL> = ({
+  closeModal,
+  invitationLink,
+}) => {
+  const history = useHistory();
+
+  const closeAndRedirectToOverview = () => {
+    closeModal();
+    history.push(`${paths.overview}`);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    closeModal();
+    history.push(
+      `${paths.logoutPage}?redirectTo=${encodeURIComponent(
+        `/join/${invitationLink}`,
+      )}`,
+    );
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <ModalHeader closeModal={closeAndRedirectToOverview}>
+        <h3>
+          <Trans i18nKey="Log in with another account" />
+        </h3>
+      </ModalHeader>
+      <ModalContent>
+        <div className="modalCancelContent">
+          <AlertOrangeIcon />
+          <div>
+            <Trans i18nKey="Project link no access info 1/2" />
+          </div>
+          <Trans i18nKey="Project link no access info 2/2" />
+        </div>
+      </ModalContent>
+      <ModalFooter>
+        <ModalFooterButtonDiv>
+          <button
+            className="button-large cancel"
+            onClick={closeAndRedirectToOverview}
+            type="button"
+          >
+            <Trans i18nKey="No, thanks" />
+          </button>
+        </ModalFooterButtonDiv>
+        <ModalFooterButtonDiv>
+          <button className="button-large" type="submit">
+            <Trans i18nKey="Yes, log in again" />
+          </button>
+        </ModalFooterButtonDiv>
+      </ModalFooter>
+    </Form>
+  );
+};

--- a/frontend/src/components/modals/JoinProjectModal.tsx
+++ b/frontend/src/components/modals/JoinProjectModal.tsx
@@ -1,0 +1,85 @@
+import { Trans, useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { StoreDispatchType } from '../../redux';
+import { roadmapsActions } from '../../redux/roadmaps';
+import { userActions } from '../../redux/user';
+import { RootState } from '../../redux/types';
+import { Modal, ModalTypes } from './types';
+import { StepForm } from '../forms/StepForm';
+import { userInfoSelector } from '../../redux/user/selectors';
+import { UserInfo } from '../../redux/user/types';
+import { paths } from '../../routers/paths';
+import { ReactComponent as MailIcon } from '../../icons/mail_icon.svg';
+import { RoleType } from '../../../../shared/types/customTypes';
+import '../../shared.scss';
+
+export const JoinProjectModal: Modal<ModalTypes.JOIN_PROJECT_MODAL> = ({
+  closeModal,
+  invitation,
+}) => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const { t } = useTranslation();
+  const history = useHistory();
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  )!;
+
+  const closeAndRedirectToOverview = () => {
+    closeModal();
+    history.push(`${paths.overview}`);
+  };
+
+  const handleSubmit = async () => {
+    const res = await dispatch(
+      userActions.joinRoadmap({
+        user: userInfo,
+        invitationLink: invitation.id,
+      }),
+    );
+    if (userActions.joinRoadmap.rejected.match(res))
+      return { message: res.payload?.message ?? '' };
+    await dispatch(roadmapsActions.getRoadmaps());
+  };
+
+  const steps = [
+    {
+      component: () => (
+        <div className="modalCancelContent">
+          <MailIcon />
+          <div>
+            <Trans
+              i18nKey="Join project info 1/2"
+              values={{
+                name: invitation.roadmap!.name,
+                type: RoleType[invitation.type],
+              }}
+            />
+          </div>
+          <Trans i18nKey="Join project info 2/2" />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <StepForm
+      header={t('Join project')}
+      finishHeader={t('New project added')}
+      finishMessage={
+        <Trans
+          i18nKey="New project added description"
+          values={{
+            name: invitation.roadmap!.name,
+          }}
+        />
+      }
+      cancelHeader={t('Cancel joining project')}
+      cancelMessage={t('Cancel join project warning')}
+      submit={handleSubmit}
+      closeModal={closeAndRedirectToOverview}
+      steps={steps}
+    />
+  );
+};

--- a/frontend/src/components/modals/ModalRoot.tsx
+++ b/frontend/src/components/modals/ModalRoot.tsx
@@ -26,6 +26,9 @@ import { UserAuthTokenModal } from './UserAuthTokenModal';
 import { AddRoadmapModal } from './AddRoadmapModal';
 import { NotifyUsersModal } from './NotifyUsersModal';
 import { SendInvitationModal } from './SendInvitationModal';
+import { JoinProjectModal } from './JoinProjectModal';
+import { JoinLinkInvalidModal } from './JoinLinkInvalidModal';
+import { JoinLinkNoAccessModal } from './JoinLinkNoAccessModal';
 
 const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.ADD_TASK_MODAL]: AddTaskModal,
@@ -47,6 +50,9 @@ const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.DELETE_ROADMAP_MODAL]: DeleteRoadmapModal,
   [ModalTypes.NOTIFY_USERS_MODAL]: NotifyUsersModal,
   [ModalTypes.SEND_INVITATION_MODAL]: SendInvitationModal,
+  [ModalTypes.JOIN_PROJECT_MODAL]: JoinProjectModal,
+  [ModalTypes.JOIN_LINK_INVALID_MODAL]: JoinLinkInvalidModal,
+  [ModalTypes.JOIN_LINK_NO_ACCESS_MODAL]: JoinLinkNoAccessModal,
 } as const;
 
 // TODO: move this to css file

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -27,6 +27,9 @@ export enum ModalTypes {
   ADD_ROADMAP_MODAL = 'ADD_ROADMAP_MODAL',
   DELETE_ROADMAP_MODAL = 'DELETE_ROADMAP_MODAL',
   NOTIFY_USERS_MODAL = 'NOTIFY_USERS_MODAL',
+  JOIN_PROJECT_MODAL = 'JOIN_PROJECT_MODAL',
+  JOIN_LINK_INVALID_MODAL = 'JOIN_LINK_INVALID_MODAL',
+  JOIN_LINK_NO_ACCESS_MODAL = 'JOIN_LINK_NO_ACCESS_MODAL',
 }
 
 type OwnProps = {
@@ -74,6 +77,9 @@ type OwnProps = {
     id: number;
   };
   [ModalTypes.NOTIFY_USERS_MODAL]: { taskId: number };
+  [ModalTypes.JOIN_PROJECT_MODAL]: { invitation: Invitation };
+  [ModalTypes.JOIN_LINK_INVALID_MODAL]: {};
+  [ModalTypes.JOIN_LINK_NO_ACCESS_MODAL]: { invitationLink: string };
 };
 
 type Props = {

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -249,5 +249,27 @@ export const english = {
     'Change address': 'Change address',
     'verify email before your journey':
       'Before your journey in Visdom, we need to verify your email address.',
+    'Join project': 'Join project',
+    'Join project info 1/2':
+      'You have been invited to join <strong>{{name}}</strong> as <strong>{{type}}</strong>',
+    'Join project info 2/2': 'Join project now?',
+    'Cancel joining project': 'Cancel joining project',
+    'Cancel join project warning':
+      'Are you sure you want to cancel joining this project?',
+    'New project added': 'New project added',
+    'New project added description':
+      'Awesome! <strong>{{name}}</strong> has been added in your projects.',
+    'No, thanks': 'No, thanks',
+    'Project link invalid': 'Project link invalid',
+    'Project link invalid info 1/2': 'Oops! Project link has gone bad.',
+    'Project link invalid info 2/2':
+      'Please request a new link from the person who invited you.',
+    'OK!': 'OK!',
+    'Log in with another account': 'Log in with another account',
+    'Project link no access info 1/2':
+      'You cannot join project with current account.',
+    'Project link no access info 2/2':
+      'Do you want to log in again with different email to join?',
+    'Yes, log in again': 'Yes, log in again',
   },
 };

--- a/frontend/src/icons/alert_orange_icon.svg
+++ b/frontend/src/icons/alert_orange_icon.svg
@@ -1,0 +1,24 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="56" height="56" fill="#E5E5E5"/>
+<g filter="url(#filter0_d_910_51)">
+<path d="M-228 -104C-228 -115.046 -219.046 -124 -208 -124H264C275.046 -124 284 -115.046 284 -104V260C284 271.046 275.046 280 264 280H-208C-219.046 280 -228 271.046 -228 260V-104Z" fill="white"/>
+</g>
+<circle cx="28" cy="28" r="28" fill="#FFAC30"/>
+<g clip-path="url(#clip0_910_51)">
+<path d="M33.2224 15.4004H22.7784L15.4004 22.7784V33.2154L22.7784 40.6004H33.2154L40.6004 33.2224V22.7784L33.2224 15.4004ZM28.0004 35.4204C26.9994 35.4204 26.1804 34.6084 26.1804 33.6004C26.1804 32.5994 26.9994 31.7804 28.0004 31.7804C29.0014 31.7804 29.8204 32.5924 29.8204 33.6004C29.8204 34.6084 29.0014 35.4204 28.0004 35.4204ZM29.4004 29.4004H26.6004V21.0004H29.4004V29.4004Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_910_51" x="-248" y="-134" width="552" height="444" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="10"/>
+<feGaussianBlur stdDeviation="10"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_910_51"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_910_51" result="shape"/>
+</filter>
+<clipPath id="clip0_910_51">
+<rect width="33.6" height="33.6" fill="white" transform="translate(11.2002 11.2002)"/>
+</clipPath>
+</defs>
+</svg>

--- a/frontend/src/pages/JoinRoadmapPage.tsx
+++ b/frontend/src/pages/JoinRoadmapPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { AxiosError } from 'axios';
 import { StoreDispatchType } from '../redux';
-import { roadmapsActions } from '../redux/roadmaps';
+import { userActions } from '../redux/user';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from '../components/modals/types';
 import { requireLogin } from '../utils/requirelogin';
@@ -17,7 +17,7 @@ const JoinRoadmapComponent = () => {
 
   useEffect(() => {
     if (invitationLink) {
-      dispatch(roadmapsActions.getInvitation(invitationLink))
+      dispatch(userActions.getInvitation(invitationLink))
         .unwrap()
         .then((invitation) =>
           dispatch(

--- a/frontend/src/pages/LogoutPage.tsx
+++ b/frontend/src/pages/LogoutPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Trans } from 'react-i18next';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { Redirect } from 'react-router-dom';
+import { Redirect, useLocation, matchPath } from 'react-router-dom';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { StoreDispatchType } from '../redux';
 import { RootState } from '../redux/types';
@@ -16,6 +16,12 @@ export const LogoutPage = () => {
     userInfoSelector,
     shallowEqual,
   );
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+
+  const joining = !!matchPath(queryParams.get('redirectTo') || '', {
+    path: paths.joinRoadmap,
+  });
 
   useEffect(() => {
     if (userInfo) {
@@ -23,18 +29,15 @@ export const LogoutPage = () => {
     }
   }, [dispatch, userInfo]);
 
+  if (!userInfo && joining)
+    return <Redirect to={`${paths.loginPage}${search}`} />;
+  if (!userInfo) return <Redirect to={paths.home} />;
   return (
     <>
-      {!userInfo ? (
-        <Redirect to={paths.home} />
-      ) : (
-        <>
-          <p>
-            <Trans i18nKey="Logging out" />
-          </p>
-          <LoadingSpinner />
-        </>
-      )}
+      <p>
+        <Trans i18nKey="Logging out" />
+      </p>
+      <LoadingSpinner />
     </>
   );
 };

--- a/frontend/src/pages/ProjectOverviewPage.tsx
+++ b/frontend/src/pages/ProjectOverviewPage.tsx
@@ -16,7 +16,7 @@ import css from './ProjectOverviewPage.module.scss';
 
 const classes = classNames.bind(css);
 
-const ProjectOverviewComponent = () => {
+export const ProjectOverviewComponent = () => {
   const dispatch = useDispatch<StoreDispatchType>();
   const roadmaps = useSelector<RootState, Roadmap[] | undefined>(
     roadmapsSelector,

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -539,18 +539,6 @@ export const getInvitations = createAsyncThunk<
   }
 });
 
-export const getInvitation = createAsyncThunk<
-  Invitation,
-  string,
-  { rejectValue: AxiosError }
->('roadmaps/getInvitation', async (invitationId, thunkAPI) => {
-  try {
-    return await api.getInvitation(invitationId);
-  } catch (err) {
-    return thunkAPI.rejectWithValue(err as AxiosError<any>);
-  }
-});
-
 export const patchInvitation = createAsyncThunk<
   { roadmapId: number; invitation: Invitation },
   InvitationRequest,

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -539,6 +539,18 @@ export const getInvitations = createAsyncThunk<
   }
 });
 
+export const getInvitation = createAsyncThunk<
+  Invitation,
+  string,
+  { rejectValue: AxiosError }
+>('roadmaps/getInvitation', async (invitationId, thunkAPI) => {
+  try {
+    return await api.getInvitation(invitationId);
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err as AxiosError<any>);
+  }
+});
+
 export const patchInvitation = createAsyncThunk<
   { roadmapId: number; invitation: Invitation },
   InvitationRequest,

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -29,6 +29,7 @@ import {
   notifyUsers,
   sendInvitation,
   getInvitations,
+  getInvitation,
   patchInvitation,
   deleteInvitation,
 } from './actions';
@@ -142,6 +143,7 @@ export const roadmapsActions = {
   notifyUsers,
   sendInvitation,
   getInvitations,
+  getInvitation,
   patchInvitation,
   deleteInvitation,
 };

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -29,7 +29,6 @@ import {
   notifyUsers,
   sendInvitation,
   getInvitations,
-  getInvitation,
   patchInvitation,
   deleteInvitation,
 } from './actions';
@@ -143,7 +142,6 @@ export const roadmapsActions = {
   notifyUsers,
   sendInvitation,
   getInvitations,
-  getInvitation,
   patchInvitation,
   deleteInvitation,
 };

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -200,6 +200,7 @@ export interface Invitation {
   email: string;
   updatedAt: string;
   valid: boolean;
+  roadmap?: { name: string };
 }
 
 export interface InvitationRequest {

--- a/frontend/src/redux/user/actions.ts
+++ b/frontend/src/redux/user/actions.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
 import { UserLoginRequest, UserInfo, UserRegisterRequest } from './types';
 import { api } from '../../api/api';
-import { RoadmapRoleResponse } from '../roadmaps/types';
+import { RoadmapRoleResponse, Invitation } from '../roadmaps/types';
 
 export const getUserInfo = createAsyncThunk<
   UserInfo,
@@ -68,6 +68,18 @@ export const patchDefaultRoadmap = createAsyncThunk<
     return await api.patchDefaultRoadmap(userId, roadmapId);
   } catch (err) {
     return thunkAPI.rejectWithValue(err);
+  }
+});
+
+export const getInvitation = createAsyncThunk<
+  Invitation,
+  string,
+  { rejectValue: AxiosError }
+>('roadmaps/getInvitation', async (invitationId, thunkAPI) => {
+  try {
+    return await api.getInvitation(invitationId);
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err as AxiosError<any>);
   }
 });
 

--- a/frontend/src/redux/user/index.ts
+++ b/frontend/src/redux/user/index.ts
@@ -7,6 +7,7 @@ import {
   patchDefaultRoadmap,
   joinRoadmap,
   verifyEmail,
+  getInvitation,
 } from './actions';
 import { UserState } from './types';
 import {
@@ -14,6 +15,7 @@ import {
   LOGOUT_FULFILLED,
   JOIN_ROADMAP_FULFILLED,
   VERIFY_EMAIL_FULFILLED,
+  GET_INVITATION_FULFILLED,
 } from './reducers';
 
 const initialState: UserState = {
@@ -27,6 +29,7 @@ export const userSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(getUserInfo.fulfilled, GET_USER_INFO_FULFILLED);
     builder.addCase(logout.fulfilled, LOGOUT_FULFILLED);
+    builder.addCase(getInvitation.fulfilled, GET_INVITATION_FULFILLED);
     builder.addCase(joinRoadmap.fulfilled, JOIN_ROADMAP_FULFILLED);
     builder.addCase(verifyEmail.fulfilled, VERIFY_EMAIL_FULFILLED);
   },
@@ -39,6 +42,7 @@ export const userActions = {
   logout,
   register,
   patchDefaultRoadmap,
+  getInvitation,
   joinRoadmap,
   verifyEmail,
 };

--- a/frontend/src/redux/user/reducers.ts
+++ b/frontend/src/redux/user/reducers.ts
@@ -13,13 +13,17 @@ export const LOGOUT_FULFILLED = (state: UserState) => {
   state.info = undefined;
 };
 
+export const GET_INVITATION_FULFILLED = (state: UserState) => {
+  if (!state.info) throw new Error('UserInfo has not been fetched yet');
+  state.info.emailVerified = true;
+};
+
 export const JOIN_ROADMAP_FULFILLED = (
   state: UserState,
   action: PayloadAction<RoadmapRoleResponse>,
 ) => {
   if (!state.info) throw new Error('UserInfo has not been fetched yet');
   state.info.roles.push(action.payload);
-  state.info.emailVerified = true;
 };
 
 export const VERIFY_EMAIL_FULFILLED = (

--- a/server/src/api/invitations/invitations.model.ts
+++ b/server/src/api/invitations/invitations.model.ts
@@ -1,6 +1,7 @@
-import { Model, Pojo } from 'objection';
+import { Model, Pojo, QueryBuilder } from 'objection';
 import { RoleType } from '../../../../shared/types/customTypes';
 import { daysAgo } from '../../utils/date';
+import Roadmap from '../roadmaps/roadmaps.model';
 
 export default class Invitation extends Model {
   id!: string;
@@ -10,6 +11,7 @@ export default class Invitation extends Model {
   updatedAt!: Date;
 
   valid?: boolean;
+  roadmap?: Roadmap;
 
   static tableName = 'invitations';
 
@@ -35,5 +37,19 @@ export default class Invitation extends Model {
 
     json.valid = json.updatedAt >= daysAgo(2);
     return json;
+  }
+  static get relationMappings() {
+    return {
+      roadmap: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Roadmap,
+        filter: (query: QueryBuilder<Model, Model[]>) =>
+          query.select('roadmaps.name'),
+        join: {
+          from: 'invitations.roadmapId',
+          to: 'roadmaps.id',
+        },
+      },
+    };
   }
 }

--- a/server/src/api/users/users.controller.ts
+++ b/server/src/api/users/users.controller.ts
@@ -150,6 +150,19 @@ export const getUserRoles: RouteHandlerFnc = async (ctx) => {
   ctx.body = roles;
 };
 
+export const getInvitation: RouteHandlerFnc = async (ctx) => {
+  if (!ctx.state.user) throw new Error('User is required');
+
+  const invitation = await Invitation.query()
+    .where({ id: ctx.params.invitationId })
+    .withGraphFetched('roadmap')
+    .first();
+
+  if (!invitation || !invitation.valid) return void (ctx.status = 404);
+  if (invitation.email !== ctx.state.user.email) return void (ctx.status = 403);
+  return void (ctx.body = invitation);
+};
+
 export const joinRoadmap: RouteHandlerFnc = async (ctx) => {
   if (!ctx.state.user) throw new Error('User is required');
   const { ...others } = ctx.request.body;

--- a/server/src/api/users/users.routes.ts
+++ b/server/src/api/users/users.routes.ts
@@ -12,6 +12,7 @@ import {
   loginUser,
   getCurrentUser,
   logoutUser,
+  getInvitation,
   joinRoadmap,
   verifyEmail,
   sendNewVerificationLink,
@@ -35,6 +36,7 @@ userRouter.post('/login', loginUser);
 userRouter.get('/logout', logoutUser);
 userRouter.get('/whoami', requireAuth, getCurrentUser);
 userRouter.get('/roles', requireAuth, getUserRoles);
+userRouter.get('/join/:invitationId', requireAuth, getInvitation);
 userRouter.post('/:userId/join/:invitationId', requireAuth, joinRoadmap);
 userRouter.post(
   '/:userId/verifyEmail/:verificationId',


### PR DESCRIPTION
https://trello.com/c/RL4FP1Up/401-figman-invitation-modaalit-fronttiin

To complete this card: https://trello.com/c/iRRBRA7S/398-handling-of-expired-invite-links-in-frontend 
I thought figma's invitation modals should be put into use. The invitation workflow is changed: first a get invitation request is sent and depending on the response a corresponding modal is opened. 
 - if invitation is fetched => JoinProjectModal
 - if response status is 403 => JoinLinkNoAccessModal
 - other => JoinLinkUnvalidModal

User is redirected to overview page on modal close
  - However, earlier the user was redirected to the new dashboard on successful project join. Opinions on whether to redirect to overview or dashboard page in this case?

