### PR TITLE
Add task ratings edition to TaskOverviewPage

### DIFF
--- a/frontend/src/components/RatingTable.module.scss
+++ b/frontend/src/components/RatingTable.module.scss
@@ -13,6 +13,7 @@
   margin: 16px 0 26px 26px;
   align-items: center;
   text-align: start;
+  gap: 24px;
 }
 
 .subtitleContainer {
@@ -51,7 +52,7 @@
   }
 }
 
-.value {
+.leftSide {
   @extend .typography-h3;
   @extend .layout-row;
   margin-left: auto;

--- a/frontend/src/components/RatingTable.tsx
+++ b/frontend/src/components/RatingTable.tsx
@@ -1,10 +1,25 @@
-import { FC, CSSProperties, useRef, useState, useEffect } from 'react';
+import {
+  FC,
+  CSSProperties,
+  useRef,
+  useState,
+  useEffect,
+  MouseEvent,
+} from 'react';
+import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { VariableSizeList } from 'react-window';
 import classNames from 'classnames';
 import { Taskrating } from '../redux/roadmaps/types';
 import { FilterTypes } from '../utils/TaskUtils';
 import { titleCase } from '../utils/string';
+import { StoreDispatchType } from '../redux';
+import { RootState } from '../redux/types';
+import { userInfoSelector } from '../redux/user/selectors';
+import { UserInfo } from '../redux/user/types';
+import { modalsActions } from '../redux/modals';
+import { ModalTypes } from './modals/types';
+import { EditButton } from './forms/SvgButton';
 import { TaskRatingDimension } from '../../../shared/types/customTypes';
 import { BusinessIcon, WorkRoundIcon } from './RoleIcons';
 import colors from '../colors.module.scss';
@@ -28,6 +43,7 @@ interface RatingTableDef {
 }
 
 type RatingTableProps = {
+  taskId: number;
   ratings: Taskrating[];
   avg: number;
   searchFilter?: FilterTypes;
@@ -38,7 +54,15 @@ type RatingTableProps = {
 export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
   Row,
   type,
-}) => ({ ratings, avg, height = 500 }) => {
+}) => ({ taskId, ratings, avg, height = 500 }) => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  )!;
+  const editable = ratings.some(
+    ({ createdByUser }) => createdByUser === userInfo.id,
+  );
   const listRef = useRef<VariableSizeList<any> | null>(null);
   const [divRef, setDivRef] = useState<HTMLDivElement | null>(null);
   const { t } = useTranslation();
@@ -67,17 +91,32 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
     listRef.current!.resetAfterIndex(0);
   }, [ratings, divRef]);
 
+  const openRateModal = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dispatch(
+      modalsActions.showModal({
+        modalType: ModalTypes.RATE_TASK_MODAL,
+        modalProps: {
+          taskId,
+          edit: true,
+        },
+      }),
+    );
+  };
+
   return (
     <div className={classes(css.ratingContainer)}>
       <div className={classes(css.titleContainer)}>
         <h2>{t('Ratings title', { type: titleCase(t(typeString)) })}</h2>
+        {editable && <EditButton fontSize="medium" onClick={openRateModal} />}
       </div>
       <div
         style={{ marginRight: scrollBarWidth }}
         className={classes(css.subtitleContainer)}
       >
         <div>{t('Average type', { type: t(typeString) })}</div>
-        <div className={classes(css.value)}>
+        <div className={classes(css.leftSide)}>
           {type === TaskRatingDimension.BusinessValue ? (
             <BusinessIcon color={colors.black100} size="small" />
           ) : (

--- a/frontend/src/components/RatingTableValue.tsx
+++ b/frontend/src/components/RatingTableValue.tsx
@@ -28,7 +28,7 @@ const TableValueRatingRow: RatingRow = ({ rating, style }) => {
           </div>
           <div className={classes(css.bottomRow, css.name)}>{user.email}</div>
         </div>
-        <div className={classes(css.value)}>
+        <div className={classes(css.leftSide)}>
           {numFormat.format(rating.value)}
         </div>
       </div>

--- a/frontend/src/components/RatingTableWork.tsx
+++ b/frontend/src/components/RatingTableWork.tsx
@@ -22,7 +22,7 @@ const TableWorkRatingRow: RatingRow = ({ rating, style }) => {
       <div className={classes(css.topRow)}>
         <BuildSharpIcon fontSize="small" />
         <div className={classes(css.name)}>{user.email}</div>
-        <div className={classes(css.value)}>
+        <div className={classes(css.leftSide)}>
           {numFormat.format(rating.value)}
         </div>
       </div>

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -132,10 +132,18 @@ const TaskOverview: FC<{
       {hasPermission(role, Permission.RoadmapReadUsers) && (
         <div className={classes(css.ratings)}>
           {valueRatings.length > 0 && (
-            <RatingTableValue ratings={valueRatings} avg={value.avg} />
+            <RatingTableValue
+              ratings={valueRatings}
+              avg={value.avg}
+              taskId={task.id}
+            />
           )}
           {workRatings.length > 0 && (
-            <RatingTableWork ratings={workRatings} avg={work.avg} />
+            <RatingTableWork
+              ratings={workRatings}
+              avg={work.avg}
+              taskId={task.id}
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
I diverged from figma's design, as task rating modal displays multiple ratings. There would be no need to find the rating from a (possibly long) rating list if user can edit all of their given ratings through one button.