### PR TITLE
Show sidebar scrollbar on hover

### DIFF
--- a/frontend/src/components/RoadmapSidebar.module.scss
+++ b/frontend/src/components/RoadmapSidebar.module.scss
@@ -8,9 +8,13 @@
 .buttonsContainer {
   @extend .layout-column;
   overflow-y: auto;
+  overflow-x: hidden;
   height: 100%;
 
-  @extend .hide-scrollbar;
+  // smaller scrollbar to prevent text clipping
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
 }
 
 .navButton {
@@ -26,8 +30,8 @@
   @extend .typography-pre-title;
 
   color: $COLOR_BLACK100;
-  border-left: 5px solid white;
-  border-right: 5px solid white;
+  border-left: 10px solid white;
+  border-right: 10px solid white;
   padding: 0 -5px;
 
   &:hover {

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -1,4 +1,5 @@
 @import './typography.scss';
+@import './colors.module.scss';
 
 html {
   font-family: Work Sans, Arial, Helvetica, sans-serif;
@@ -33,4 +34,17 @@ h3 {
   width: 100%;
   text-align: center;
   overflow-y: auto;
+}
+
+// custom scrollbar
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+::-webkit-scrollbar-track {
+  background-color: $COLOR_BLACK10;
+}
+::-webkit-scrollbar-thumb {
+  border-radius: 49px;
+  background-color: $COLOR_BLACK40 !important;
 }


### PR DESCRIPTION
Windows scrollbar would be annoyingly large and would stretch the sidebar on hover pushing other content to the right.
<img height="400" src="https://user-images.githubusercontent.com/80758782/148188160-d456f46e-16a7-404f-9510-25a205981ffa.png"/>

So I propose a custom scrollbar found in figma and showing it on hover. (the scrollbar is used everywhere else too though - stylistically I am not sure if it's an improvement for mac and linux users)