### PR TITLE
Add time-work calibration value to roadmap model

### DIFF
--- a/server/src/api/roadmaps/roadmaps.controller.ts
+++ b/server/src/api/roadmaps/roadmaps.controller.ts
@@ -54,7 +54,13 @@ export const postRoadmaps: RouteHandlerFnc = async (ctx) => {
 };
 
 export const patchRoadmaps: RouteHandlerFnc = async (ctx) => {
-  const { id, name, description, ...others } = ctx.request.body;
+  const {
+    id,
+    name,
+    description,
+    daysPerWorkCalibration,
+    ...others
+  } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const updated = await Roadmap.query().patchAndFetchById(

--- a/server/src/api/roadmaps/roadmaps.model.ts
+++ b/server/src/api/roadmaps/roadmaps.model.ts
@@ -9,6 +9,7 @@ export default class Roadmap extends Model {
   id!: number;
   name!: string;
   description!: string;
+  daysPerWorkCalibration?: number;
 
   customers!: Customer[];
   roles!: Role[];
@@ -25,6 +26,7 @@ export default class Roadmap extends Model {
       id: { type: 'integer' },
       name: { type: 'string', minLength: 1, maxLength: 255 },
       description: { type: 'string', minLength: 1, maxLength: 1000 },
+      daysPerWorkCalibration: { type: 'float' },
     },
   };
 

--- a/server/src/migrations/20220111090109_workTimeCalibration.ts
+++ b/server/src/migrations/20220111090109_workTimeCalibration.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('roadmaps', (table) => {
+    table.float('daysPerWorkCalibration').nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('roadmaps', (table) => {
+    table.dropColumn('daysPerWorkCalibration');
+  });
+}

--- a/server/tests/roadmaps.test.ts
+++ b/server/tests/roadmaps.test.ts
@@ -17,7 +17,13 @@ describe('Test /roadmaps/ api', function () {
 
       expect(res.status).to.equal(200);
       expect(res.body.length).to.equal(fetchedAgent.roadmaps.length);
-      expect(res.body[0]).to.have.keys('id', 'name', 'description', 'tasks');
+      expect(res.body[0]).to.have.keys(
+        'id',
+        'name',
+        'description',
+        'tasks',
+        'daysPerWorkCalibration',
+      );
     });
 
     it('Should return all roadmaps, eager loaded', async function () {
@@ -33,6 +39,7 @@ describe('Test /roadmaps/ api', function () {
         'name',
         'description',
         'tasks',
+        'daysPerWorkCalibration',
         'integrations',
       );
       expect(res.body[0].tasks[0]).to.have.keys(


### PR DESCRIPTION
Backend support for persisting a time-work calibration value that can then be used in time estimation features