### PR TITLE
Fix dropdown menu overextension

### DIFF
--- a/frontend/src/components/RoadmapSelectorWidget.module.scss
+++ b/frontend/src/components/RoadmapSelectorWidget.module.scss
@@ -1,76 +1,78 @@
 @import '../shared.scss';
 
 .dropContainer {
+  position: relative;
   margin-top: 12px;
+  min-width: 60px;
+  max-width: 200px;
 }
 
 .dropButton {
-  @extend .layout-row;
   @extend .typography-body-small;
+  position: relative;
   align-items: center;
+  white-space: nowrap;
+  margin-right: 0;
+  margin-left: auto;
   border-radius: 16px;
   border: 2px solid $COLOR_EMERALD;
-  box-sizing: border-box;
   height: 32px;
-  background-color: transparent;
-  justify-content: space-between;
-  padding: 0px 16px;
+  padding: 0px 26px 0px 16px;
+  background-color: $COLOR_BLACK5;
 
   &:hover,
   &:focus {
-    outline: none;
     background: white;
+    outline: none;
   }
   &:disabled {
-    color: $COLOR_BLACK40;
     cursor: not-allowed;
+    color: $COLOR_BLACK40;
   }
 }
 
 .dropMenu {
-  @extend .layout-column;
-  width: auto;
+  position: absolute;
+  z-index: 4;
+  left: 0;
+  overflow: hidden; // Overflow needs to be hidden or border-corners will be hid
+  word-wrap: break-word;
+  margin-top: 5px;
   border: 1px solid $COLOR_BLACK10;
   border-radius: 4%;
-  align-items: center;
-  overflow: hidden;
-  margin-top: 4px;
-  z-index: 999;
+  min-width: 130px;
+  max-width: 200px;
+  width: auto;
 }
 
 .menuCanvas {
   background-color: white;
-  width: 100%;
-  z-index: 999;
-}
-
-.emptyTitle {
-  color: #696969;
 }
 
 .dropItem {
   @extend .typography-body-small;
-  background-color: white;
-  border: none;
   display: block;
-  width: 100%;
-  text-decoration: none;
+  border: none;
+  padding: 3px 10px;
   color: $COLOR_BLACK100;
-  padding: 3px;
+  text-align: left;
 
   &:hover,
   &:focus {
     background-color: $COLOR_BLACK5;
     color: $COLOR_BLACK100;
-    cursor: pointer;
     text-decoration: none;
-    outline: none;
   }
 }
 
 .expandIcon {
-  margin-right: -8px;
-  margin-left: 6px;
-  width: 17px !important;
-  height: 17px !important;
+  position: absolute;
+  top: 6.5px;
+  right: 8px;
+  width: 17px;
+  height: 17px;
+}
+
+.emptyTitle {
+  color: $COLOR_BLACK60;
 }


### PR DESCRIPTION
Fixes a bug where roadmap-selector dropdown menu would break if the names were too long. Also improved the general look a bit and cleaned up and refactored the css file.