### PR TITLE
Fix flaky roadmap test

### DIFF
--- a/server/tests/roadmaps.test.ts
+++ b/server/tests/roadmaps.test.ts
@@ -42,7 +42,9 @@ describe('Test /roadmaps/ api', function () {
         'daysPerWorkCalibration',
         'integrations',
       );
-      expect(res.body[0].tasks[0]).to.have.keys(
+      expect(
+        res.body.find((rm: any) => rm.tasks.length > 0)?.tasks[0],
+      ).to.have.keys(
         'id',
         'name',
         'description',


### PR DESCRIPTION
Roadmap test can no longer use index 0 of api response since the order they are listed is not constant. Roadmap with tasks must be searched for first.