### PR TITLE
Reset password frontend

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
-    NodeJS: true, // See: https://github.com/Chatie/eslint-config/issues/45
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
+    NodeJS: true, // See: https://github.com/Chatie/eslint-config/issues/45
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -439,6 +439,21 @@ const leaveRoadmap = async (roadmapId: number) => {
   return successful(response.status);
 };
 
+const sendPasswordResetLink = async (email: string) => {
+  const response = await axios.post('/users/sendPasswordResetLink', {
+    email,
+  });
+  return response.status === 200;
+};
+
+const resetPassword = async (token: string, password: string) => {
+  const response = await axios.post('/users/resetPassword', {
+    token,
+    password,
+  });
+  return response.status === 200;
+};
+
 export const api = {
   getRoadmaps,
   addRoadmap,
@@ -491,4 +506,6 @@ export const api = {
   removeTaskRelation,
   addSynergyRelations,
   leaveRoadmap,
+  sendPasswordResetLink,
+  resetPassword,
 };

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -443,7 +443,7 @@ const sendPasswordResetLink = async (email: string) => {
   const response = await axios.post('/users/sendPasswordResetLink', {
     email,
   });
-  return response.status === 200;
+  return successful(response.status);
 };
 
 const resetPassword = async (token: string, password: string) => {
@@ -451,7 +451,7 @@ const resetPassword = async (token: string, password: string) => {
     token,
     password,
   });
-  return response.status === 200;
+  return successful(response.status);
 };
 
 export const api = {

--- a/frontend/src/components/LoginNavBar.tsx
+++ b/frontend/src/components/LoginNavBar.tsx
@@ -45,6 +45,16 @@ const navBars: {
     path: paths.notFound,
     linkHome: true,
   },
+  {
+    path: paths.forgotPassword,
+    button: { to: (search) => paths.home + search, label: 'Home' },
+    linkHome: true,
+  },
+  {
+    path: paths.resetPassword,
+    button: { to: (search) => paths.home + search, label: 'Home' },
+    linkHome: true,
+  },
 ];
 
 export const findLoginNavBar = (pathname: string, loggedIn: boolean) => {

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -333,5 +333,7 @@ export const english = {
     'Token not found': 'Token not found.',
     'Token expired': 'Token expired.',
     'Error message': 'Error: {{error}}.',
+    'Email service error': 'Email service error',
+    'This email doesn’t exist': 'This email doesn’t exist',
   },
 };

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -316,5 +316,22 @@ export const english = {
     'Personal auth token tooltip': 'TBD',
     'Taskmap-tooltip':
       'New synergy group can be created by dragging a task outside of existing groups.\n\nRelations can be deleted by right clicking them or hovering over and pressing backspace or delete.',
+    'Forgot password': 'Forgot password?',
+    'Remembered password': 'Remembered password?',
+    'Forgot password subtitle':
+      'No worries, enter your registered email address and we’ll send you a link to reset your password.',
+    'Reset link sent': 'Reset link sent',
+    'Resend link': 'Resend link',
+    'Didn’t receive the email': 'Didn’t receive the email?',
+    'Reset link sent successfully': 'Reset link sent successfully.',
+    'Reset password': 'Reset password',
+    'We have sent an email':
+      'We have sent an email to <strong>{{email}}</strong> for you to reset your password',
+    'Retry timer': 'Retry in {{time}}s',
+    'Password set success':
+      '<strong>All done!</strong> Your new password has been set.',
+    'Token not found': 'Token not found.',
+    'Token expired': 'Token expired.',
+    'Error message': 'Error: {{error}}.',
   },
 };

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -327,7 +327,7 @@ export const english = {
     'Reset password': 'Reset password',
     'We have sent an email':
       'We have sent an email to <strong>{{email}}</strong> for you to reset your password',
-    'Retry timer': 'Retry in {{time}}s',
+    'Retry timer': 'Try again in {{time}}s',
     'Password set success':
       '<strong>All done!</strong> Your new password has been set.',
     'Token not found': 'Token not found.',

--- a/frontend/src/pages/ForgotPassword.module.scss
+++ b/frontend/src/pages/ForgotPassword.module.scss
@@ -1,0 +1,9 @@
+@import '../shared.scss';
+
+.secondSubtitle {
+  text-align: center;
+}
+
+.secondSubtitle > svg:first-of-type {
+  margin-bottom: 24px;
+}

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -22,9 +22,7 @@ export const ForgotPasswordPage = () => {
   const [linkSent, setLinkSent] = useState(false);
   const [email, setEmail] = useState('');
   const [resendDisabled, setResendDisabled] = useState(false);
-  const [resendDisableTime, setResendDisableTime] = useState(
-    defaultDisableSeconds,
-  );
+  const [resendDisableTime, setResendDisableTime] = useState(0);
   const [errorMessage, setErrorMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -47,8 +45,8 @@ export const ForgotPasswordPage = () => {
     return api.sendPasswordResetLink(email);
   };
 
-  const createDisableTimer = () => {
-    setResendDisableTime(defaultDisableSeconds);
+  const createDisableTimer = (time: number) => {
+    setResendDisableTime(time);
     setResendDisabled(true);
 
     const countdownInterval = setInterval(() => {
@@ -58,8 +56,7 @@ export const ForgotPasswordPage = () => {
     setTimeout(() => {
       clearInterval(countdownInterval);
       setResendDisabled(false);
-      setResendDisableTime(defaultDisableSeconds);
-    }, defaultDisableSeconds * 1000);
+    }, time * 1000);
   };
 
   const isUniqueError = (err: any) => err.response?.status === 404;
@@ -81,7 +78,7 @@ export const ForgotPasswordPage = () => {
       return;
     }
 
-    createDisableTimer();
+    createDisableTimer(defaultDisableSeconds / 2);
     setErrorMessage('');
     setIsLoading(false);
     setLinkSent(true);
@@ -89,7 +86,7 @@ export const ForgotPasswordPage = () => {
 
   const handleResend = () => {
     sendEmailLink();
-    createDisableTimer();
+    createDisableTimer(defaultDisableSeconds);
   };
 
   const sendLinkView = () => (

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,152 @@
+import { useState, FormEvent } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import classNames from 'classnames';
+import { ModalContent } from '../components/modals/modalparts/ModalContent';
+import { ModalHeader } from '../components/modals/modalparts/ModalHeader';
+import { Footer } from '../components/Footer';
+import { paths } from '../routers/paths';
+import { Input } from '../components/forms/FormField';
+import { ReactComponent as MailIcon } from '../icons/mail_icon.svg';
+import { api } from '../api/api';
+import css from './ForgotPassword.module.scss';
+
+const classes = classNames.bind(css);
+
+export const ForgotPasswordPage = () => {
+  const { t } = useTranslation();
+  const defaultDisableTime = 30; // Seconds
+
+  const [view, setView] = useState('Send link');
+  const [email, setEmail] = useState('');
+  const [resendDisabled, setResendDisabled] = useState(false);
+  const [disableTime, setDisableTime] = useState(defaultDisableTime);
+
+  const sendEmailLink = () => {
+    api.sendPasswordResetLink(email);
+  };
+
+  const disableSending = () => {
+    setResendDisabled(true);
+
+    const countdownInterval = setInterval(() => {
+      if (disableTime > 0) setDisableTime((previous) => previous - 1);
+    }, 1000);
+
+    setTimeout(() => setResendDisabled(false), defaultDisableTime * 1000);
+    setTimeout(() => {
+      clearInterval(countdownInterval);
+      setDisableTime(defaultDisableTime);
+    }, defaultDisableTime * 1000);
+  };
+
+  const handleSend = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    sendEmailLink();
+    setView('Link sent');
+  };
+
+  const handleResend = () => {
+    sendEmailLink();
+    setDisableTime(defaultDisableTime);
+    disableSending();
+  };
+
+  const sendLinkView = () => {
+    return (
+      <div className="formDiv">
+        <ModalHeader>
+          <h2>
+            <Trans i18nKey="Forgot password" />
+          </h2>
+        </ModalHeader>
+        <ModalContent gap={30}>
+          <div className="formSubtitle">
+            <Trans i18nKey="Forgot password subtitle" />
+          </div>
+          <form onSubmit={handleSend}>
+            <Input
+              label={t('Your email')}
+              required
+              id="email"
+              type="email"
+              placeholder={t('Email')}
+              value={email}
+              onChange={(e) => setEmail(e.currentTarget.value)}
+            />
+            <button className="button-large" type="submit">
+              <Trans i18nKey="Send link" />
+            </button>
+          </form>
+          <div className="formFooter">
+            <Trans i18nKey="Remembered password" />{' '}
+            <Link to={`${paths.loginPage}`}>
+              <Trans i18nKey="Log in" />
+            </Link>
+          </div>
+        </ModalContent>
+      </div>
+    );
+  };
+
+  const linkSentView = () => {
+    return (
+      <div className="formDiv">
+        <ModalHeader>
+          <h2>
+            <Trans i18nKey="Reset link sent" />
+          </h2>
+        </ModalHeader>
+        <ModalContent gap={30}>
+          <div className={classes(css.secondSubtitle)}>
+            <MailIcon />
+            <p>
+              <Trans i18nKey="We have sent an email" values={{ email }} />
+            </p>
+          </div>
+          <div className="formFooter" style={{ textAlign: 'center' }}>
+            <div style={{ marginBottom: '16px' }}>
+              <Trans i18nKey="Wrong email address?" />{' '}
+              <button
+                className={classes(css.linkButton, css.green)}
+                type="button"
+                onClick={() => setView('Send link')}
+              >
+                <Trans i18nKey="Change address" />
+              </button>
+            </div>
+            <div>
+              {!resendDisabled && (
+                <>
+                  <Trans i18nKey="Didn’t receive the email" />{' '}
+                  <button
+                    type="button"
+                    className={classes(css.linkButton, css.green)}
+                    onClick={handleResend}
+                  >
+                    <Trans i18nKey="Resend link" />
+                  </button>
+                </>
+              )}
+              {resendDisabled && (
+                <>
+                  <Trans i18nKey="Reset link sent successfully" />{' '}
+                  <Trans i18nKey="Retry timer" values={{ time: disableTime }} />
+                </>
+              )}
+            </div>
+          </div>
+        </ModalContent>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {view === 'Send link' && sendLinkView()}
+      {view === 'Link sent' && linkSentView()}
+      <Footer />
+    </>
+  );
+};

--- a/frontend/src/pages/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage.module.scss
@@ -2,9 +2,7 @@
 
 .loginFooter {
   @extend .formFooter;
+  @extend .layout-column;
+  gap: 16px;
   text-align: center;
-}
-
-.loginFooter > div:first-of-type {
-  margin-bottom: 16px;
 }

--- a/frontend/src/pages/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage.module.scss
@@ -1,1 +1,10 @@
 @import '../shared.scss';
+
+.loginFooter {
+  @extend .formFooter;
+  text-align: center;
+}
+
+.loginFooter > div:first-of-type {
+  margin-bottom: 16px;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -120,11 +120,9 @@ export const LoginPage = () => {
                 <Trans i18nKey="Register" />
               </Link>
             </div>
-            <div>
-              <Link to={`${paths.forgotPassword}`}>
-                <Trans i18nKey="Forgot password" />
-              </Link>
-            </div>
+            <Link to={`${paths.forgotPassword}`}>
+              <Trans i18nKey="Forgot password" />
+            </Link>
           </div>
         </ModalContent>
       </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -113,11 +113,18 @@ export const LoginPage = () => {
               </button>
             )}
           </form>
-          <div className={classes(css.formFooter)}>
-            <Trans i18nKey="No account?" />{' '}
-            <Link to={`${paths.registerPage}${urlSearchString}`}>
-              <Trans i18nKey="Register" />
-            </Link>
+          <div className={classes(css.loginFooter)}>
+            <div>
+              <Trans i18nKey="No account?" />{' '}
+              <Link to={`${paths.registerPage}${urlSearchString}`}>
+                <Trans i18nKey="Register" />
+              </Link>
+            </div>
+            <div>
+              <Link to={`${paths.forgotPassword}`}>
+                <Trans i18nKey="Forgot password" />
+              </Link>
+            </div>
           </div>
         </ModalContent>
       </div>

--- a/frontend/src/pages/ResetPasswordPage.module.scss
+++ b/frontend/src/pages/ResetPasswordPage.module.scss
@@ -1,0 +1,10 @@
+@import '../shared.scss';
+
+.doneSubtitle {
+  text-align: center;
+}
+
+.doneCheckIcon,
+.doneSubtitleText {
+  margin-bottom: 40px;
+}

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -33,7 +33,7 @@ export const ResetPasswordPage = () => {
     err: errorState(useState('')),
   };
 
-  const handleReset = (e: FormEvent<HTMLFormElement>) => {
+  const handleReset = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     e.stopPropagation();
     if (password !== confirmPassword) {
@@ -43,19 +43,18 @@ export const ResetPasswordPage = () => {
 
     if (!token) return;
 
-    dispatch(userActions.resetPassword({ token, password })).then((res) => {
-      if (userActions.resetPassword.rejected.match(res)) {
-        if (res.payload?.response?.status === 403)
-          setErrorMessage(t('Token expired'));
-        else if (res.payload?.response?.status === 404)
-          setErrorMessage(t('Token not found'));
-        else if (res.payload) {
-          setErrorMessage(t('Error message', { error: res.payload.message }));
-        }
-      } else {
-        setDone(true);
-      }
-    });
+    const res = await dispatch(userActions.resetPassword({ token, password }));
+    if (!userActions.resetPassword.rejected.match(res)) {
+      setDone(true);
+      return;
+    }
+
+    if (res.payload?.response?.status === 403)
+      setErrorMessage(t('Token expired'));
+    else if (res.payload?.response?.status === 404)
+      setErrorMessage(t('Token not found'));
+    else if (res.payload)
+      setErrorMessage(t('Error message', { error: res.payload.message }));
   };
 
   const resetPasswordView = () => (

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -24,7 +24,7 @@ export const ResetPasswordPage = () => {
     token: string | undefined;
   }>();
 
-  const [view, setView] = useState('Reset password');
+  const [done, setDone] = useState(false);
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -53,107 +53,100 @@ export const ResetPasswordPage = () => {
           setErrorMessage(t('Error message', { error: res.payload.message }));
         }
       } else {
-        setView('Done');
+        setDone(true);
       }
     });
   };
 
-  const resetPasswordView = () => {
-    return (
-      <>
-        <div className="formDiv">
-          <ModalHeader>
-            <h2>
-              <Trans i18nKey="Reset password" />
-            </h2>
-          </ModalHeader>
-          <ModalContent gap={30}>
-            <div className="formSubtitle">
-              <Trans i18nKey="Enter your new password below" />
-            </div>
-            <form onSubmit={handleReset}>
-              <Input
-                label={t('New password')}
-                required
-                minLength={8}
-                maxLength={72}
-                id="password"
-                type="password"
-                placeholder={t('Password')}
-                value={password}
-                onChange={(e) => setPassword(e.currentTarget.value)}
-              />
-              <Input
-                label={t('Confirm new password')}
-                required
-                id="confirm password"
-                type="password"
-                placeholder={t('Confirm password')}
-                value={confirmPassword}
-                error={confirmationError.err}
-                onChange={(e) => setConfirmPassword(e.currentTarget.value)}
-              />
-              <button className="button-large" type="submit">
-                <Trans i18nKey="Reset password" />
-              </button>
-              <Alert
-                show={errorMessage.length > 0}
-                variant="danger"
-                dismissible
-                onClose={() => setErrorMessage('')}
-              >
-                {errorMessage}
-              </Alert>
-            </form>
-            <div className="formFooter">
-              <Trans i18nKey="Remembered password" />{' '}
-              <Link to={`${paths.loginPage}`}>
-                <Trans i18nKey="Log in" />
-              </Link>
-            </div>
-          </ModalContent>
+  const resetPasswordView = () => (
+    <div className="formDiv">
+      <ModalHeader>
+        <h2>
+          <Trans i18nKey="Reset password" />
+        </h2>
+      </ModalHeader>
+      <ModalContent gap={30}>
+        <div className="formSubtitle">
+          <Trans i18nKey="Enter your new password below" />
         </div>
-      </>
-    );
-  };
+        <form onSubmit={handleReset}>
+          <Input
+            label={t('New password')}
+            required
+            minLength={8}
+            maxLength={72}
+            id="password"
+            type="password"
+            placeholder={t('Password')}
+            value={password}
+            onChange={(e) => setPassword(e.currentTarget.value)}
+          />
+          <Input
+            label={t('Confirm new password')}
+            required
+            id="confirm password"
+            type="password"
+            placeholder={t('Confirm password')}
+            value={confirmPassword}
+            error={confirmationError.err}
+            onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+          />
+          <button className="button-large" type="submit">
+            <Trans i18nKey="Reset password" />
+          </button>
+          <Alert
+            show={errorMessage.length > 0}
+            variant="danger"
+            dismissible
+            onClose={() => setErrorMessage('')}
+          >
+            {errorMessage}
+          </Alert>
+        </form>
+        <div className="formFooter">
+          <Trans i18nKey="Remembered password" />{' '}
+          <Link to={`${paths.loginPage}`}>
+            <Trans i18nKey="Log in" />
+          </Link>
+        </div>
+      </ModalContent>
+    </div>
+  );
 
-  const doneView = () => {
-    return (
-      <div className="formDiv">
-        <ModalHeader>
-          <h2>
-            <Trans i18nKey="Password reset" />
-          </h2>
-        </ModalHeader>
-        <ModalContent gap={30}>
-          <div className={classes(css.doneSubtitle)}>
-            <div className={classes(css.doneCheckIcon)}>
-              <CheckIcon />
-            </div>
-            <div className={classes(css.doneSubtitleText)}>
-              <p>
-                <Trans i18nKey="Password set success" />
-              </p>
-            </div>
-            <div>
-              <button
-                className="button-large"
-                type="button"
-                onClick={() => history.push(paths.loginPage)}
-              >
-                <Trans i18nKey="Go to Login" />
-              </button>
-            </div>
+  const doneView = () => (
+    <div className="formDiv">
+      <ModalHeader>
+        <h2>
+          <Trans i18nKey="Password reset" />
+        </h2>
+      </ModalHeader>
+      <ModalContent gap={30}>
+        <div className={classes(css.doneSubtitle)}>
+          <div className={classes(css.doneCheckIcon)}>
+            <CheckIcon />
           </div>
-        </ModalContent>
-      </div>
-    );
-  };
+          <div className={classes(css.doneSubtitleText)}>
+            <p>
+              <Trans i18nKey="Password set success" />
+            </p>
+          </div>
+          <div>
+            <button
+              className="button-large"
+              type="button"
+              onClick={() => history.push(paths.loginPage)}
+            >
+              <Trans i18nKey="Go to Login" />
+            </button>
+          </div>
+        </div>
+      </ModalContent>
+    </div>
+  );
 
   return (
     <>
-      {view === 'Reset password' && resetPasswordView()}
-      {view === 'Done' && doneView()}
+      {done ? doneView() : resetPasswordView()}
       <Footer />
     </>
   );

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,160 @@
+import { useState, FormEvent } from 'react';
+import { useDispatch } from 'react-redux';
+import { Trans, useTranslation } from 'react-i18next';
+import { Alert } from 'react-bootstrap';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import classNames from 'classnames';
+import { userActions } from '../redux/user';
+import { ModalContent } from '../components/modals/modalparts/ModalContent';
+import { ModalHeader } from '../components/modals/modalparts/ModalHeader';
+import { Input, errorState } from '../components/forms/FormField';
+import { Footer } from '../components/Footer';
+import { paths } from '../routers/paths';
+import { StoreDispatchType } from '../redux';
+import { ReactComponent as CheckIcon } from '../icons/check_icon.svg';
+import css from './ResetPasswordPage.module.scss';
+
+const classes = classNames.bind(css);
+
+export const ResetPasswordPage = () => {
+  const dispatch = useDispatch<StoreDispatchType>();
+  const history = useHistory();
+  const { t } = useTranslation();
+  const { token } = useParams<{
+    token: string | undefined;
+  }>();
+
+  const [view, setView] = useState('Reset password');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const confirmationError = {
+    err: errorState(useState('')),
+  };
+
+  const handleReset = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (password !== confirmPassword) {
+      confirmationError.err.setMessage(t('Password confirmation error'));
+      return;
+    }
+
+    if (!token) return;
+
+    dispatch(userActions.resetPassword({ token, password })).then((res) => {
+      if (userActions.resetPassword.rejected.match(res)) {
+        if (res.payload?.response?.status === 403)
+          setErrorMessage(t('Token expired'));
+        else if (res.payload?.response?.status === 404)
+          setErrorMessage(t('Token not found'));
+        else if (res.payload) {
+          setErrorMessage(t('Error message', { error: res.payload.message }));
+        }
+      } else {
+        setView('Done');
+      }
+    });
+  };
+
+  const resetPasswordView = () => {
+    return (
+      <>
+        <div className="formDiv">
+          <ModalHeader>
+            <h2>
+              <Trans i18nKey="Reset password" />
+            </h2>
+          </ModalHeader>
+          <ModalContent gap={30}>
+            <div className="formSubtitle">
+              <Trans i18nKey="Enter your new password below" />
+            </div>
+            <form onSubmit={handleReset}>
+              <Input
+                label={t('New password')}
+                required
+                minLength={8}
+                maxLength={72}
+                id="password"
+                type="password"
+                placeholder={t('Password')}
+                value={password}
+                onChange={(e) => setPassword(e.currentTarget.value)}
+              />
+              <Input
+                label={t('Confirm new password')}
+                required
+                id="confirm password"
+                type="password"
+                placeholder={t('Confirm password')}
+                value={confirmPassword}
+                error={confirmationError.err}
+                onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+              />
+              <button className="button-large" type="submit">
+                <Trans i18nKey="Reset password" />
+              </button>
+              <Alert
+                show={errorMessage.length > 0}
+                variant="danger"
+                dismissible
+                onClose={() => setErrorMessage('')}
+              >
+                {errorMessage}
+              </Alert>
+            </form>
+            <div className="formFooter">
+              <Trans i18nKey="Remembered password" />{' '}
+              <Link to={`${paths.loginPage}`}>
+                <Trans i18nKey="Log in" />
+              </Link>
+            </div>
+          </ModalContent>
+        </div>
+      </>
+    );
+  };
+
+  const doneView = () => {
+    return (
+      <div className="formDiv">
+        <ModalHeader>
+          <h2>
+            <Trans i18nKey="Password reset" />
+          </h2>
+        </ModalHeader>
+        <ModalContent gap={30}>
+          <div className={classes(css.doneSubtitle)}>
+            <div className={classes(css.doneCheckIcon)}>
+              <CheckIcon />
+            </div>
+            <div className={classes(css.doneSubtitleText)}>
+              <p>
+                <Trans i18nKey="Password set success" />
+              </p>
+            </div>
+            <div>
+              <button
+                className="button-large"
+                type="button"
+                onClick={() => history.push(paths.loginPage)}
+              >
+                <Trans i18nKey="Go to Login" />
+              </button>
+            </div>
+          </div>
+        </ModalContent>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {view === 'Reset password' && resetPasswordView()}
+      {view === 'Done' && doneView()}
+      <Footer />
+    </>
+  );
+};

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -29,15 +29,13 @@ export const ResetPasswordPage = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const confirmationError = {
-    err: errorState(useState('')),
-  };
+  const confirmationError = errorState(useState(''));
 
   const handleReset = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     e.stopPropagation();
     if (password !== confirmPassword) {
-      confirmationError.err.setMessage(t('Password confirmation error'));
+      confirmationError.setMessage(t('Password confirmation error'));
       return;
     }
 
@@ -87,7 +85,7 @@ export const ResetPasswordPage = () => {
             type="password"
             placeholder={t('Confirm password')}
             value={confirmPassword}
-            error={confirmationError.err}
+            error={confirmationError}
             onChange={(e) => setConfirmPassword(e.currentTarget.value)}
           />
           <button className="button-large" type="submit">

--- a/frontend/src/redux/user/actions.ts
+++ b/frontend/src/redux/user/actions.ts
@@ -141,3 +141,15 @@ export const verifyEmail = createAsyncThunk<
     return thunkAPI.rejectWithValue(err as AxiosError<any>);
   }
 });
+
+export const resetPassword = createAsyncThunk<
+  boolean,
+  { token: string; password: string },
+  { rejectValue: AxiosError }
+>('resetPassword', async ({ token, password }, thunkAPI) => {
+  try {
+    return await api.resetPassword(token, password);
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err as AxiosError<any>);
+  }
+});

--- a/frontend/src/redux/user/index.ts
+++ b/frontend/src/redux/user/index.ts
@@ -10,6 +10,7 @@ import {
   joinRoadmap,
   verifyEmail,
   getInvitation,
+  resetPassword,
 } from './actions';
 import { UserState } from './types';
 import {
@@ -49,4 +50,5 @@ export const userActions = {
   getInvitation,
   joinRoadmap,
   verifyEmail,
+  resetPassword,
 };

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -24,6 +24,8 @@ import {
   VerifyEmailPage,
   EmailVerificationPage,
 } from '../pages/VerifyEmailPage';
+import { ForgotPasswordPage } from '../pages/ForgotPasswordPage';
+import { ResetPasswordPage } from '../pages/ResetPasswordPage';
 
 const Home = () => {
   const loggedInUser = useSelector<RootState, UserInfo | undefined>(
@@ -93,6 +95,16 @@ const routes = [
     path: paths.notFound,
     component: () => <NavLayout Content={NotFoundPage} />,
     exact: true,
+  },
+  {
+    path: paths.forgotPassword,
+    component: () => <NavLayout Content={ForgotPasswordPage} />,
+    exact: true,
+  },
+  {
+    path: paths.resetPassword,
+    component: () => <NavLayout Content={ResetPasswordPage} />,
+    exact: false,
   },
   {
     path: '',

--- a/frontend/src/routers/paths.ts
+++ b/frontend/src/routers/paths.ts
@@ -14,6 +14,8 @@ export const paths = {
   verifyEmail: `/verifyEmail/:verificationId(${uuidPattern})`,
   roadmapHome: '/roadmap',
   notFound: '/404',
+  forgotPassword: '/forgotpassword',
+  resetPassword: `/resetPassword/:token(${uuidPattern})`,
   roadmapRouter: '/roadmap/:roadmapId([0-9]+)',
   roadmapRelative: {
     dashboard: '/dashboard',

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -437,35 +437,34 @@ textarea {
   }
 }
 
+.link-button {
+  background-color: transparent;
+  padding: 0;
+  border: none;
+  font-weight: bold;
+}
+
 .green {
-  text-decoration: underline;
   color: $COLOR_EMERALD;
 
   &.linkButton {
-    background-color: transparent;
-    padding: 0;
-    border: none;
+    @extend .link-button;
   }
 
   &:hover {
-    text-decoration: none;
-    color: $COLOR_FOREST;
+    text-decoration: underline;
   }
 }
 
 .blue {
-  text-decoration: underline;
   color: $COLOR_AZURE;
 
   &.linkButton {
-    background-color: transparent;
-    padding: 0;
-    border: none;
+    @extend .link-button;
   }
 
   &:hover {
-    text-decoration: none;
-    color: darken($COLOR_AZURE, 10%);
+    text-decoration: underline;
   }
 }
 

--- a/server/src/api/users/users.controller.ts
+++ b/server/src/api/users/users.controller.ts
@@ -292,7 +292,7 @@ export const resetPassword: RouteHandlerFnc = async (ctx) => {
     if (!found) return 404;
     if (!found.valid) {
       ctx.body = 'Password reset link has expired';
-      return 400;
+      return 403;
     }
     const user = await User.query(trx).findById(found.userId);
     if (!user) return 404;


### PR DESCRIPTION
Some notes:
- Email view is currently accessible in /resetPasswordEmail/:token
- Email view still has things marked as to do since it will most likely need changes when actually implementing it to the email
- All of the pages are using old footers but I figured that creating new footers and applying it to all the other pages as well (email verification etc.) is not in the scope of this PR