### PR TITLE
Remove order dependency from tests

### DIFF
--- a/server/tests/tasks.test.ts
+++ b/server/tests/tasks.test.ts
@@ -3,7 +3,6 @@ import chaiHttp from 'chai-http';
 chai.use(chaiHttp);
 import { loggedInAgent } from './setuptests';
 import Roadmap from '../src/api/roadmaps/roadmaps.model';
-import User from '../src/api/users/users.model';
 import Task from '../src/api/tasks/tasks.model';
 import { Permission } from '../../shared/types/customTypes';
 import { withoutPermission } from './testUtils';

--- a/server/tests/testUtils.ts
+++ b/server/tests/testUtils.ts
@@ -60,8 +60,7 @@ export const getTestRatingData = async () => {
   const rating = await TaskRating.query()
     .first()
     .withGraphFetched('[belongsToTask.[belongsToRoadmap]]');
-  const ratingId = rating.id;
   const taskId = rating.belongsToTask?.id;
   const roadmapId = rating.belongsToTask?.belongsToRoadmap.id;
-  return { ratingId, taskId, roadmapId };
+  return { rating, taskId, roadmapId };
 };


### PR DESCRIPTION
Previously some tests depended on consistent order from database queries
and api responses, where no ordering was required for the tested functionality.