### PR TITLE
Fix bug when using multiple tabs and switching roadmaps

### DIFF
--- a/frontend/src/components/modals/DeleteModal.tsx
+++ b/frontend/src/components/modals/DeleteModal.tsx
@@ -22,7 +22,7 @@ const DeleteModalContent: FC<{
   header: string;
   action: any;
   payload: any;
-  closeModal: () => void;
+  closeModal: (success?: boolean) => void;
 }> = ({ header, action, payload, closeModal, children }) => {
   const dispatch = useDispatch<StoreDispatchType>();
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +38,7 @@ const DeleteModalContent: FC<{
       if (res.payload?.message) setErrorMessage(res.payload.message);
       return;
     }
-    closeModal();
+    closeModal(true);
   };
 
   return (
@@ -103,9 +103,9 @@ export const DeleteRoadmapModal: Modal<ModalTypes.DELETE_ROADMAP_MODAL> = ({
       header={t('Delete project')}
       action={roadmapsActions.deleteRoadmap}
       payload={{ id }}
-      closeModal={() => {
-        closeModal();
-        history.push(paths.overview);
+      closeModal={(success) => {
+        closeModal(success);
+        if (success) history.push(paths.overview);
       }}
     >
       <Trans i18nKey="Delete project confirmation">

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -4,6 +4,7 @@ import {
   Redirect,
   Route,
   Switch,
+  useHistory,
   useParams,
   useRouteMatch,
 } from 'react-router-dom';
@@ -22,6 +23,7 @@ import {
   chosenRoadmapSelector,
   roadmapUsersSelector,
   allCustomersSelector,
+  chosenRoadmapIdSelector,
 } from '../redux/roadmaps/selectors';
 import { RoadmapUser, Customer, Roadmap } from '../redux/roadmaps/types';
 import { RootState } from '../redux/types';
@@ -30,6 +32,7 @@ import { paths } from './paths';
 import { PlannerPageRouter } from './PlannerPageRouter';
 import { TasksPageRouter } from './TasksPageRouter';
 import '../shared.scss';
+import { usePrevious } from '../utils/usePrevious';
 
 const routes = [
   {
@@ -69,7 +72,12 @@ const routes = [
 
 const RoadmapRouterComponent = ({ userInfo }: { userInfo: UserInfo }) => {
   const { path } = useRouteMatch();
-  const { roadmapId } = useParams<{ roadmapId: string | undefined }>();
+  const history = useHistory();
+  const { roadmapId: urlRoadmapId } = useParams<{
+    roadmapId: string | undefined;
+  }>();
+  const selectedRoadmapId = useSelector(chosenRoadmapIdSelector);
+  const previousRoadmapId = usePrevious<number | undefined>(selectedRoadmapId);
   const dispatch = useDispatch<StoreDispatchType>();
   const currentRoadmap = useSelector<RootState, Roadmap | undefined>(
     chosenRoadmapSelector,
@@ -91,9 +99,38 @@ const RoadmapRouterComponent = ({ userInfo }: { userInfo: UserInfo }) => {
 
   useEffect(() => {
     // Try to select roadmap given in route parameters
-    if (roadmapId) {
-      dispatch(roadmapsActions.selectCurrentRoadmap(+roadmapId));
+    if (urlRoadmapId) {
+      dispatch(roadmapsActions.selectCurrentRoadmap(+urlRoadmapId));
     }
+  }, [dispatch, urlRoadmapId]);
+
+  useEffect(() => {
+    // If selectedRoadmapId changes, update the url to match that
+    // (for cases where another browser tab switches roadmapId and the state gets synced into this tab)
+    let newPath: string;
+    const roadmapIdRegex = new RegExp('^/roadmap/\\d+/');
+    if (!previousRoadmapId || selectedRoadmapId === previousRoadmapId) return;
+    if (selectedRoadmapId === undefined) {
+      newPath = '/overview';
+    } else if (history.location.pathname.match(roadmapIdRegex)) {
+      newPath = history.location.pathname.replace(
+        roadmapIdRegex,
+        `/roadmap/${selectedRoadmapId}/`,
+      );
+    } else {
+      newPath = `/roadmap/${selectedRoadmapId}${paths.roadmapRelative.dashboard}`;
+    }
+    history.push(`${newPath}${history.location.search}`);
+  }, [
+    dispatch,
+    selectedRoadmapId,
+    previousRoadmapId,
+    history.location.pathname,
+    history,
+    urlRoadmapId,
+  ]);
+
+  useEffect(() => {
     if (!currentRoadmap) {
       setIsLoadingRoadmap(true);
       dispatch(roadmapsActions.getRoadmaps()).then(() => {
@@ -121,7 +158,7 @@ const RoadmapRouterComponent = ({ userInfo }: { userInfo: UserInfo }) => {
       });
     }
     setUseEffectFinished(true);
-  }, [currentRoadmap, roadmapId, dispatch, roadmapUsers, customers, type]);
+  }, [currentRoadmap, urlRoadmapId, dispatch, roadmapUsers, customers, type]);
 
   if (!useEffectFinished) return null;
   if (!isLoadingRoadmap && !currentRoadmap)

--- a/frontend/src/utils/usePrevious.ts
+++ b/frontend/src/utils/usePrevious.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react';
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value;
+  }, [value]); // Only re-run if value changes
+  // Return previous value (happens before update in useEffect above)
+  return ref.current;
+}


### PR DESCRIPTION
I couldn't fix the edge case of another tab not navigating from /overview to /roadmap/id/dashboard if the state gets synced. Im guessing its because of checking for an existing `previousRoadmapId` before running the useEffect, but since `undefined` is a valid roadmapId (not selected) the useEffect/usePrevious cant tell the difference between the first render & intentionally null/undefined roadmap
`if (previousRoadmapId && selectedRoadmapId !== previousRoadmapId) {`

removing the check causes infinite loops and exploding galaxies. It might be fixable if we refactor our state to use `null` for intentionally nonexistent values to tell them apart from `undefined`
