### PR TITLE
Fix constraint on task table

### DIFF
--- a/server/src/migrations/20220208124324_fixTaskImportConstraint.ts
+++ b/server/src/migrations/20220208124324_fixTaskImportConstraint.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('tasks', (table) => {
+    table.dropUnique(['externalId', 'importedFrom']);
+    table.unique(['roadmapId', 'externalId', 'importedFrom']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Do nothing, the previous constraint was incorrect,
+  // and as it was also stricter this might cause conflicts.
+}


### PR DESCRIPTION
This adds the roadmapId to the constraint, so that the same task can be
imported to multiple roadmaps.