### PR TITLE
Fix css priority in production builds

### DIFF
--- a/frontend/src/components/TaskMapEdge.module.scss
+++ b/frontend/src/components/TaskMapEdge.module.scss
@@ -1,23 +1,23 @@
 @import '../shared.scss';
 
 .firstStop {
-  stop-color: $COLOR_FOREST;
+  stop-color: $COLOR_FOREST !important;
 }
 .secondStop {
-  stop-color: $COLOR_ORANGE;
+  stop-color: $COLOR_ORANGE !important;
 }
 
 .invisiblePath {
-  stroke: $COLOR_AZURE;
-  pointer-events: all;
-  stroke-width: 15;
-  opacity: 0;
-  cursor: pointer;
+  stroke: $COLOR_AZURE !important;
+  pointer-events: all !important;
+  stroke-width: 15 !important;
+  opacity: 0 !important;
+  cursor: pointer !important;
   &:hover {
-    opacity: 0.1;
+    opacity: 0.1 !important;
   }
   &.disableInteraction {
-    cursor: -webkit-grabbing;
-    stroke: transparent;
+    cursor: -webkit-grabbing !important;
+    stroke: transparent !important;
   }
 }

--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -63,10 +63,10 @@
 .handle {
   visibility: visible;
   position: absolute;
-  border-radius: 50%;
-  height: 17px;
-  width: 17px;
-  background-color: $COLOR_WHITE;
+  border-radius: 50% !important;
+  height: 17px !important;
+  width: 17px !important;
+  background-color: $COLOR_WHITE !important;
 
   &.dragging {
     height: calc(17px * #{$ZOOM});
@@ -78,28 +78,28 @@
 .leftHandle {
   @extend .handle;
   left: -3%;
-  border: 2px solid $COLOR_ORANGE;
+  border: 2px solid $COLOR_ORANGE !important;
 
   &.filled {
-    background-color: lighten($COLOR_ORANGE, 20%);
+    background-color: lighten($COLOR_ORANGE, 20%) !important;
   }
 
   &.connectable {
-    box-shadow: 0 0 10px 4px $COLOR_ORANGE;
+    box-shadow: 0 0 10px 4px $COLOR_ORANGE !important;
   }
 }
 
 .rightHandle {
   @extend .handle;
   left: 97%;
-  border: 2px solid $COLOR_FOREST;
+  border: 2px solid $COLOR_FOREST !important;
 
   &.filled {
-    background-color: lighten($COLOR_FOREST, 20%);
+    background-color: lighten($COLOR_FOREST, 20%) !important;
   }
 
   &.connectable {
-    box-shadow: 0 0 10px 4px $COLOR_FOREST;
+    box-shadow: 0 0 10px 4px $COLOR_FOREST !important;
   }
 }
 


### PR DESCRIPTION
The custom styles were overridden by the default styles from react-flow.
This only affected production build, and has been there from the
beginning.

It would be nice to get rid of most or all the `!important`s, but this
is fine for now.