### PR TITLE
Show missing representatives

### DIFF
--- a/frontend/src/components/MissingRatings.module.scss
+++ b/frontend/src/components/MissingRatings.module.scss
@@ -22,3 +22,17 @@
   gap: 25px;
   align-items: center;
 }
+
+.titleHeader {
+  text-decoration: underline;
+}
+
+.emailList {
+  text-align: left;
+  div {
+    margin-bottom: 4px;
+    span {
+      color: $COLOR_AZURE;
+    }
+  }
+}

--- a/frontend/src/components/MissingRatings.tsx
+++ b/frontend/src/components/MissingRatings.tsx
@@ -15,6 +15,7 @@ import {
   missingCustomer,
   missingDeveloper,
   ratedByCustomer,
+  getMissingRepresentatives,
 } from '../utils/TaskUtils';
 import css from './MissingRatings.module.scss';
 import { apiV2 } from '../api/api';
@@ -74,7 +75,26 @@ export const MissingRatings: FC<{
             tooltip: classes(css.tooltip),
           }}
           key={customer.id}
-          title={customer.name}
+          title={
+            <div>
+              <p className={classes(css.titleHeader)}>{customer.name}</p>
+              <div className={classes(css.emailList)}>
+                {allUsers &&
+                  getMissingRepresentatives(customer, allUsers, task)?.map(
+                    (rep) => (
+                      <div key={`${rep.id}-${customer.id}-${task.id}`}>
+                        {rep.email}{' '}
+                        {rep.email === userInfo?.email && (
+                          <span>
+                            (<Trans i18nKey="You" />)
+                          </span>
+                        )}
+                      </div>
+                    ),
+                  )}
+              </div>
+            </div>
+          }
           placement="top"
           arrow
         >

--- a/frontend/src/components/modals/NotifyUsersModal.tsx
+++ b/frontend/src/components/modals/NotifyUsersModal.tsx
@@ -21,7 +21,10 @@ import { RoleType } from '../../../../shared/types/customTypes';
 import css from './NotifyUsersModal.module.scss';
 import { getType } from '../../utils/UserUtils';
 import { Modal, ModalTypes } from './types';
-import { missingDeveloper } from '../../utils/TaskUtils';
+import {
+  missingDeveloper,
+  getMissingRepresentatives,
+} from '../../utils/TaskUtils';
 import { TextArea } from '../forms/FormField';
 import { RoleIcon } from '../RoleIcons';
 import colors from '../../colors.module.scss';
@@ -72,25 +75,20 @@ export const NotifyUsersModal: Modal<ModalTypes.NOTIFY_USERS_MODAL> = ({
       allUsers
     ) {
       const missingRepresentativeIds = new Set<number>();
-
       customers.forEach((customer) => {
-        const ratingsForTask = task.ratings
-          .filter((rating) => rating.forCustomer === customer.id)
-          .map((e) => e.createdByUser);
-
-        customer.representatives?.forEach(({ id }) => {
-          if (
-            // skip logged in user, so they won't send email to themselves
-            id !== userInfo?.id &&
-            // skip representatives who have given a rating
-            !ratingsForTask.includes(id)
-          )
-            missingRepresentativeIds.add(id);
-        });
+        getMissingRepresentatives(
+          customer,
+          allUsers,
+          task,
+        ).forEach((representative) =>
+          missingRepresentativeIds.add(representative.id),
+        );
       });
 
       const missingRepresentatives = allUsers
-        .filter(({ id }) => missingRepresentativeIds.has(id))
+        .filter(
+          ({ id }) => userInfo!.id !== id && missingRepresentativeIds.has(id),
+        )
         .map((user) => ({ ...user, checked: false }));
 
       const missingDevelopers = allUsers

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -337,5 +337,6 @@ export const english = {
     'Error message': 'Error: {{error}}.',
     'Email service error': 'Email service error',
     'This email doesn’t exist': 'This email doesn’t exist',
+    You: 'You',
   },
 };

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -342,3 +342,19 @@ export const getRatingsByType = (ratings: Taskrating[]) => {
   );
   return { value, complexity };
 };
+
+export const getMissingRepresentatives = (
+  customer: Customer,
+  allUsers: RoadmapUser[],
+  task: Task,
+) => {
+  const missingRepresentativeIds = new Set<number>();
+  const ratingsForTask = task.ratings
+    .filter((rating) => rating.forCustomer === customer.id)
+    .map((e) => e.createdByUser);
+
+  customer.representatives?.forEach(({ id }) => {
+    if (!ratingsForTask.includes(id)) missingRepresentativeIds.add(id);
+  });
+  return allUsers.filter(({ id }) => missingRepresentativeIds.has(id));
+};


### PR DESCRIPTION
Waiting for ratings customer dots now show list of the users' emails. It uses really similar function as notifyUsers did, so I moved it to taskUtils and adjusted it a bit to match the needs of both