### PR TITLE
Perf sortable task list

### DIFF
--- a/frontend/src/components/ExpandableColumn.module.scss
+++ b/frontend/src/components/ExpandableColumn.module.scss
@@ -1,0 +1,44 @@
+@import '../shared.scss';
+
+.expandableContentWrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 366px;
+  overflow-y: auto;
+  background-color: $COLOR_BLACK10;
+  border-radius: 10px;
+  padding-bottom: 10px;
+  &.minimized {
+    width: 65px;
+  }
+}
+
+.expandableHeader {
+  display: flex;
+  align-items: center;
+  margin: 16px;
+  margin-bottom: 10px;
+
+  @extend .typography-pre-title;
+  text-align: left;
+  cursor: pointer;
+
+  svg {
+    margin-right: 11px;
+  }
+  &.minimized {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+  &.minimized > div {
+    white-space: nowrap;
+    margin-right: 16px;
+    transform: rotate(-90deg);
+    transform-origin: right;
+  }
+  &.minimized > svg {
+    margin-right: 0;
+    margin-bottom: 11px;
+  }
+}

--- a/frontend/src/components/ExpandableColumn.tsx
+++ b/frontend/src/components/ExpandableColumn.tsx
@@ -1,0 +1,37 @@
+import { FC, ReactNode, CSSProperties } from 'react';
+import classNames from 'classnames';
+import { ReactComponent as ExpandLess } from '../icons/expand_less.svg';
+import { ReactComponent as ExpandMore } from '../icons/expand_more.svg';
+import css from './ExpandableColumn.module.scss';
+
+const classes = classNames.bind(css);
+
+export const ExpandableColumn: FC<{
+  expanded: boolean;
+  onToggle: () => void;
+  title: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}> = ({ expanded, onToggle, title, children, className, style }) => (
+  <div className={className} style={style}>
+    <div
+      className={classes(css.expandableContentWrapper, {
+        [css.minimized]: !expanded,
+      })}
+    >
+      <div
+        className={classes(css.expandableHeader, {
+          [css.minimized]: !expanded,
+        })}
+        onClick={onToggle}
+        onKeyPress={onToggle}
+        role="button"
+        tabIndex={0}
+      >
+        {expanded ? <ExpandLess /> : <ExpandMore />}
+        {title}
+      </div>
+      {expanded && children}
+    </div>
+  </div>
+);

--- a/frontend/src/components/SortableTask.module.scss
+++ b/frontend/src/components/SortableTask.module.scss
@@ -13,6 +13,7 @@
   display: flex;
   justify-content: flex-start;
   text-align: left;
+  word-break: break-word;
 }
 
 .rightSideDiv {

--- a/frontend/src/components/SortableTask.tsx
+++ b/frontend/src/components/SortableTask.tsx
@@ -1,67 +1,35 @@
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import DragIndicatorIcon from '@material-ui/icons/DragIndicator';
-import { Task, Version } from '../redux/roadmaps/types';
+import { Task } from '../redux/roadmaps/types';
 import { TaskRatingsText } from './TaskRatingsText';
 import css from './SortableTask.module.scss';
-import { apiV2 } from '../api/api';
-
-interface VersionListsObject {
-  [K: string]: Task[];
-}
 
 export const SortableTask: FC<{
   task: Task;
   index: number;
   disableDragging: boolean;
-}> = ({ task, index, disableDragging }) => {
-  const { data: tasks } = apiV2.useGetTasksQuery(task.roadmapId);
-  const { data: roadmapsVersions } = apiV2.useGetVersionsQuery(task.roadmapId);
-  const [roadmapsVersionsLocal, setRoadmapsVersionsLocal] = useState<
-    undefined | Version[]
-  >(undefined);
-  const [unversionedTasks, setUnversionedTasks] = useState<Task[]>();
-
-  useEffect(() => {
-    setRoadmapsVersionsLocal(roadmapsVersions);
-  }, [roadmapsVersions]);
-
-  useEffect(() => {
-    if (roadmapsVersionsLocal === undefined) return;
-    const newVersionLists: VersionListsObject = {};
-    const unversioned = new Map(tasks?.map((t) => [t.id, t]));
-    roadmapsVersionsLocal.forEach((v) => {
-      newVersionLists[v.id] = v.tasks;
-      v.tasks.forEach((t) => unversioned.delete(t.id));
-    });
-    setUnversionedTasks(Array.from(unversioned.values()));
-  }, [roadmapsVersionsLocal, tasks]);
-
-  return (
-    <Draggable
-      key={task.id}
-      draggableId={`${task.id}`}
-      index={index}
-      isDragDisabled={disableDragging}
-    >
-      {(provided) => (
-        <div
-          className={css.taskDiv}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-        >
-          <div className={css.leftSideDiv}>{task.name}</div>
-          <div className={css.rightSideDiv}>
-            <div>
-              {unversionedTasks?.some((obj) => obj.id === task.id) && (
-                <TaskRatingsText task={task} />
-              )}
-            </div>
-            <DragIndicatorIcon fontSize="small" />
-          </div>
+  showRatings: boolean;
+}> = ({ task, index, disableDragging, showRatings }) => (
+  <Draggable
+    key={task.id}
+    draggableId={`${task.id}`}
+    index={index}
+    isDragDisabled={disableDragging}
+  >
+    {(provided) => (
+      <div
+        className={css.taskDiv}
+        ref={provided.innerRef}
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+      >
+        <div className={css.leftSideDiv}>{task.name}</div>
+        <div className={css.rightSideDiv}>
+          {showRatings && <TaskRatingsText task={task} />}
+          <DragIndicatorIcon fontSize="small" />
         </div>
-      )}
-    </Draggable>
-  );
-};
+      </div>
+    )}
+  </Draggable>
+);

--- a/frontend/src/components/SortableTaskList.module.scss
+++ b/frontend/src/components/SortableTaskList.module.scss
@@ -1,3 +1,5 @@
+@import '../shared.scss';
+
 .highlight {
   box-shadow: 0px 0px 20px rgba(0, 60, 250, 0.15);
   background-color: rgba(0, 60, 250, 0.045) !important;
@@ -10,4 +12,16 @@
   overflow-y: visible;
   background-color: transparent;
   width: 100%;
+}
+
+.sortableListWrapper {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 100px;
+  height: inherit;
+  padding: 16px;
+  scrollbar-width: thin;
+
+  @extend .typography-body-small;
 }

--- a/frontend/src/components/SortableTaskList.tsx
+++ b/frontend/src/components/SortableTaskList.tsx
@@ -11,8 +11,10 @@ export const SortableTaskList: FC<{
   listId: string;
   tasks: Task[];
   disableDragging: boolean;
-}> = ({ listId, tasks, disableDragging }) => {
-  return (
+  showRatings?: boolean;
+  className?: string;
+}> = ({ listId, tasks, disableDragging, showRatings, className }) => (
+  <div className={classes(css.sortableListWrapper, className)}>
     <Droppable droppableId={listId} type="TASKS">
       {(provided, snapshot) => (
         <div
@@ -29,11 +31,12 @@ export const SortableTaskList: FC<{
               task={task}
               index={index}
               disableDragging={disableDragging}
+              showRatings={!!showRatings}
             />
           ))}
           {provided.placeholder}
         </div>
       )}
     </Droppable>
-  );
-};
+  </div>
+);

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -1,4 +1,5 @@
 @import '../shared.scss';
+@import '../components/SortableTaskList.module.scss';
 
 .horizontalScroller {
   margin-left: 8px;
@@ -41,22 +42,10 @@
   padding: 13px;
 }
 
-.sortableListWrapper {
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  min-height: 100px;
-  height: inherit;
-  padding: 16px;
-  scrollbar-width: thin;
-
-  @extend .typography-body-small;
-
-  &.milestone {
-    padding: 0px;
-    padding-top: 7px;
-    padding-bottom: 1px;
-  }
+.sortableListWrapper.milestone {
+  padding: 0px;
+  padding-top: 7px;
+  padding-bottom: 1px;
 }
 
 .ratingsSummaryWrapper {

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -4,46 +4,22 @@
   margin-left: 8px;
 }
 
-.unorderedTasksWrapper {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 366px;
+.unorderedCol {
   margin-top: 26px;
-  background-color: $COLOR_BLACK10;
-  border-radius: 10px;
-  &.minimized {
-    width: 65px;
-  }
+  margin-bottom: 16px;
 }
 
-.unorderedTasksHeader {
-  display: flex;
-  align-items: center;
-  margin: 16px;
-  margin-bottom: 0;
-
-  @extend .typography-pre-title;
-  text-align: left;
-  cursor: pointer;
-
-  svg {
-    margin-right: 11px;
-  }
-  &.minimized {
-    flex-direction: column;
-    align-items: flex-end;
-  }
-  &.minimized > div {
-    white-space: nowrap;
-    margin-right: 16px;
-    transform: rotate(-90deg);
-    transform-origin: right;
-  }
-  &.minimized > svg {
-    margin-right: 0;
-    margin-bottom: 11px;
-  }
+.milestoneCol {
+  @extend .layoutCol;
+  justify-content: flex-start;
+  flex-grow: 0;
+  width: 200px;
+  overflow-y: visible;
+  overflow-x: visible;
+  background-color: transparent;
+  border-radius: 8px;
+  margin-left: 20px;
+  margin-bottom: 16px;
 }
 
 .milestoneHeader {

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -13,9 +13,8 @@ import InfoIcon from '@material-ui/icons/InfoOutlined';
 import { Link } from 'react-router-dom';
 import { DeleteButton, SettingsButton } from '../components/forms/SvgButton';
 import { SortableTaskList } from '../components/SortableTaskList';
+import { ExpandableColumn } from '../components/ExpandableColumn';
 import { MilestoneRatingsSummary } from '../components/MilestoneRatingsSummary';
-import { ReactComponent as ExpandLess } from '../icons/expand_less.svg';
-import { ReactComponent as ExpandMore } from '../icons/expand_more.svg';
 import { StoreDispatchType } from '../redux';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes, modalLink } from '../components/modals/types';
@@ -288,7 +287,7 @@ export const MilestonesEditor = () => {
             >
               {(draggableProvided) => (
                 <div
-                  className={classes(css.layoutCol, css.milestoneCol)}
+                  className={classes(css.milestoneCol)}
                   ref={draggableProvided.innerRef}
                   {...draggableProvided.draggableProps}
                 >
@@ -338,7 +337,7 @@ export const MilestonesEditor = () => {
               )}
             </Draggable>
           ))}
-          <div className={classes(css.layoutCol, css.milestoneCol)}>
+          <div className={classes(css.milestoneCol)}>
             <div
               className={classes(css.milestoneWrapper, css.addNewBtnWrapper)}
               onClick={addVersion}
@@ -374,43 +373,26 @@ export const MilestonesEditor = () => {
         </div>
       </InfoTooltip>
       <div className={classes(css.layoutRow, css.overflowYAuto)}>
-        <div
-          className={classes(css.layoutCol, css.unorderedTasksCol, {
-            [css.minimized]: !expandUnordered,
-          })}
-        >
-          <div
-            className={classes(css.unorderedTasksWrapper, {
-              [css.minimized]: !expandUnordered,
-            })}
-          >
-            <div
-              className={classes(css.unorderedTasksHeader, {
-                [css.minimized]: !expandUnordered,
-              })}
-              onClick={() => setExpandUnordered(!expandUnordered)}
-              onKeyPress={() => setExpandUnordered(!expandUnordered)}
-              role="button"
-              tabIndex={0}
-            >
-              {expandUnordered ? <ExpandLess /> : <ExpandMore />}
-              <div>
-                {`${t('Unordered tasks')} (${
-                  versionLists[ROADMAP_LIST_ID]?.length ?? 0
-                })`}
-              </div>
+        <ExpandableColumn
+          className={classes(css.unorderedCol)}
+          expanded={expandUnordered}
+          onToggle={() => setExpandUnordered((prev) => !prev)}
+          title={
+            <div>
+              {`${t('Unordered tasks')} (${
+                versionLists[ROADMAP_LIST_ID]?.length ?? 0
+              })`}
             </div>
-            {expandUnordered && (
-              <div className={classes(css.sortableListWrapper)}>
-                <SortableTaskList
-                  listId={ROADMAP_LIST_ID}
-                  tasks={versionLists[ROADMAP_LIST_ID] || []}
-                  disableDragging={disableDrag}
-                />
-              </div>
-            )}
+          }
+        >
+          <div className={classes(css.sortableListWrapper)}>
+            <SortableTaskList
+              listId={ROADMAP_LIST_ID}
+              tasks={versionLists[ROADMAP_LIST_ID] || []}
+              disableDragging={disableDrag}
+            />
           </div>
-        </div>
+        </ExpandableColumn>
         {roadmapsVersionsLocal && renderMilestones()}
       </div>
     </DragDropContext>

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -299,18 +299,12 @@ export const MilestonesEditor = () => {
                       {version.name}
                     </div>
 
-                    <div
-                      className={classes(
-                        css.sortableListWrapper,
-                        css.milestone,
-                      )}
-                    >
-                      <SortableTaskList
-                        listId={`${version.id}`}
-                        tasks={versionLists[version.id] || []}
-                        disableDragging={disableDrag}
-                      />
-                    </div>
+                    <SortableTaskList
+                      listId={`${version.id}`}
+                      tasks={versionLists[version.id] || []}
+                      disableDragging={disableDrag}
+                      className={classes(css.milestone)}
+                    />
                     <div className={classes(css.ratingsSummaryWrapper)}>
                       <MilestoneRatingsSummary
                         tasks={versionLists[version.id] || []}
@@ -385,13 +379,12 @@ export const MilestonesEditor = () => {
             </div>
           }
         >
-          <div className={classes(css.sortableListWrapper)}>
-            <SortableTaskList
-              listId={ROADMAP_LIST_ID}
-              tasks={versionLists[ROADMAP_LIST_ID] || []}
-              disableDragging={disableDrag}
-            />
-          </div>
+          <SortableTaskList
+            listId={ROADMAP_LIST_ID}
+            tasks={versionLists[ROADMAP_LIST_ID] || []}
+            disableDragging={disableDrag}
+            showRatings
+          />
         </ExpandableColumn>
         {roadmapsVersionsLocal && renderMilestones()}
       </div>

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -138,29 +138,6 @@ form {
   &.roadmapPageContainer {
     padding: 0 23px 0 20px;
   }
-  &.unorderedTasksCol {
-    flex: 1;
-    flex-grow: 0;
-    width: 366px;
-    overflow-y: visible;
-    overflow-x: visible;
-    margin-bottom: 16px;
-    background-color: transparent;
-    &.minimized {
-      width: 65px;
-    }
-  }
-  &.milestoneCol {
-    justify-content: flex-start;
-    flex-grow: 0;
-    width: 200px;
-    overflow-y: visible;
-    overflow-x: visible;
-    background-color: transparent;
-    border-radius: 8px;
-    margin-left: 20px;
-    margin-bottom: 16px;
-  }
 }
 
 .plannerPagecontainer {


### PR DESCRIPTION
This improves the rendering of milestone editor page's "unordered tasks" list greatly.

From 2-3 s to expand and show the names and another ~5 s to display the ratings with 418 unordered tasks (out of 423),
to ~1 s.