### PR TITLE
Task map list for individual tasks

### DIFF
--- a/frontend/src/components/SortableTaskList.tsx
+++ b/frontend/src/components/SortableTaskList.tsx
@@ -11,11 +11,23 @@ export const SortableTaskList: FC<{
   listId: string;
   tasks: Task[];
   disableDragging: boolean;
+  isDropDisabled?: boolean;
   showRatings?: boolean;
   className?: string;
-}> = ({ listId, tasks, disableDragging, showRatings, className }) => (
+}> = ({
+  listId,
+  tasks,
+  disableDragging,
+  showRatings,
+  className,
+  isDropDisabled,
+}) => (
   <div className={classes(css.sortableListWrapper, className)}>
-    <Droppable droppableId={listId} type="TASKS">
+    <Droppable
+      isDropDisabled={isDropDisabled}
+      droppableId={listId}
+      type="TASKS"
+    >
       {(provided, snapshot) => (
         <div
           className={classes(css.sortableList, {

--- a/frontend/src/pages/TaskMapPage.module.scss
+++ b/frontend/src/pages/TaskMapPage.module.scss
@@ -4,22 +4,24 @@ $ZOOM: var(--zoom, 1);
 
 .taskmap {
   @extend .layout-column;
+  height: 100%;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .flowContainer {
   @extend .layout-row;
+  height: 100%;
   width: 100%;
   background-color: $COLOR_WHITE;
   border-radius: 10px;
   min-height: 300px;
-  margin-top: 10px;
 }
 
 .taskOverviewContainer {
   @extend .layout-row;
   margin-top: 20px;
   margin-left: 10px;
-  min-height: 140px;
 }
 
 .info {

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -81,11 +81,6 @@ type Edge = {
   };
 };
 
-/* eslint-disable */
-const isEdge = (x: Edge | Group): x is Edge => x.type === 'custom';
-const isGroup = (x: Edge | Group): x is Group => x.type === 'special';
-/* eslint-enable */
-
 export const TaskMapPage = () => {
   const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
@@ -170,39 +165,41 @@ export const TaskMapPage = () => {
 
     const graph = getAutolayout(measuredRelations);
 
-    const groups: Group[] = measuredRelations.flatMap(({ id, synergies }) => {
-      const node = graph.node(id);
-      if (!tasks) return [];
-      return [
-        {
-          id,
-          type: 'special',
-          sourcePosition: Position.Right,
-          targetPosition: Position.Left,
-          draggable: false,
-          // dagre coordinates are in the center, calculate top left corner
-          position: { x: node.x - node.width / 2, y: node.y - node.height / 2 },
-          data: {
-            label: (
-              <TaskGroup
-                listId={id}
-                taskIds={synergies}
-                tasks={tasks}
-                selectedTask={selectedTask}
-                setSelectedTask={setSelectedTask}
-                allDependencies={taskRelations.flatMap(
-                  ({ dependencies }) => dependencies,
-                )}
-                disableDragging={disableDrag}
-                disableDrop={dropUnavailable.has(id)}
-                unavailable={unavailable}
-                dragHandle={dragHandle}
-              />
-            ),
-          },
-        },
-      ];
-    });
+    const groups: Group[] = !tasks
+      ? []
+      : measuredRelations.map(({ id, synergies }) => {
+          const node = graph.node(id);
+          return {
+            id,
+            type: 'special',
+            sourcePosition: Position.Right,
+            targetPosition: Position.Left,
+            draggable: false,
+            // dagre coordinates are in the center, calculate top left corner
+            position: {
+              x: node.x - node.width / 2,
+              y: node.y - node.height / 2,
+            },
+            data: {
+              label: (
+                <TaskGroup
+                  listId={id}
+                  taskIds={synergies}
+                  tasks={tasks}
+                  selectedTask={selectedTask}
+                  setSelectedTask={setSelectedTask}
+                  allDependencies={taskRelations.flatMap(
+                    ({ dependencies }) => dependencies,
+                  )}
+                  disableDragging={disableDrag}
+                  disableDrop={dropUnavailable.has(id)}
+                  unavailable={unavailable}
+                  dragHandle={dragHandle}
+                />
+              ),
+            },
+          };
+        });
 
     const edges: Edge[] = measuredRelations.flatMap(({ dependencies }, idx) =>
       dependencies.flatMap(({ from, to }) => {

--- a/frontend/src/utils/TaskRelationUtils.ts
+++ b/frontend/src/utils/TaskRelationUtils.ts
@@ -1,5 +1,5 @@
 import dagre from 'dagre';
-import { Task, TaskRelation } from '../redux/roadmaps/types';
+import { TaskRelation } from '../redux/roadmaps/types';
 import { TaskRelationType } from '../../../shared/types/customTypes';
 
 export enum TaskRelationTableType {
@@ -27,12 +27,10 @@ const existingSynergyIdxs = (subgroup: number[], groups: GroupedRelation[]) => {
   return idxs;
 };
 
-export const groupTaskRelations = (
-  tasks: Task[],
-  relations: TaskRelation[],
-) => {
+export const groupTaskRelations = (relations: TaskRelation[]) => {
   const groups: GroupedRelation[] = [];
-  tasks.forEach(({ id }) => {
+  const ids = new Set(relations.flatMap(({ from, to }) => [from, to]));
+  ids.forEach((id) => {
     const subgroup: GroupedRelation = {
       synergies: [id],
       dependencies: [],


### PR DESCRIPTION
This splits the tasks in task map to staged (having relations or manually added), and unstaged (all the rest) tasks.
The unstaged tasks in a list for now, but that should be simple to change.

The unstaged tasks can be staged by dragging to the task map, either individually or into existing group.