### PR TITLE
Move task map edges back on the z-axis

### DIFF
--- a/frontend/src/components/TaskMapTaskGroup.module.scss
+++ b/frontend/src/components/TaskMapTaskGroup.module.scss
@@ -5,7 +5,7 @@
   position: relative;
   padding: 20px 15px;
   width: 405px;
-  background-color: $COLOR_CLOUD;
+  background-color: rgba($COLOR_CLOUD, 0.75);
   border-radius: 10px;
   cursor: default;
 

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -608,7 +608,7 @@ textarea {
 }
 
 .react-flow__edges {
-  z-index: 3 !important;
+  z-index: 2 !important;
 }
 
 .react-flow__controls {


### PR DESCRIPTION
Previously the edges were in front of the task groups. Thus the edges
could obstruct a task making it unreadable. The edge's hit box is also
larger than the visual size, and can block interactions on a task below
it.

Now the edges are rendered below the task groups. The task group
background has some transparency to make it easier to see, where the
edge connects to. The existing hover effect also helps tracing an
individual edge, even if it goes under task groups.