### PR TITLE
Rework milestone editor logic, fix issue with rtk-query

### DIFF
--- a/server/src/api/versions/versions.controller.ts
+++ b/server/src/api/versions/versions.controller.ts
@@ -129,6 +129,15 @@ export const patchVersions: RouteHandlerFnc = async (ctx) => {
 
     // TODO: separate adding/deleting from updating
     if (tasks) {
+      // Delete tasks from all versions
+      await trx('versionTasks')
+        .whereIn(
+          'versionTasks.taskId',
+          tasks.map((taskId: number) => taskId),
+        )
+        .delete();
+
+      // Wipe current versions tasks list and reconstruct it
       await trx('versionTasks').where('versionId', versionId).delete();
       if (tasks?.length) {
         await trx('versionTasks').insert(


### PR DESCRIPTION
Removed unnecessary optimistic update logic from milestone editor.
Made backend patchVersions route remove tasks from any previous versions when they are added to a new version.
Cleaned up milestone editor and fixed issues with rtk-query