### PR TITLE
Fix user patching

### DIFF
--- a/frontend/src/redux/user/actions.ts
+++ b/frontend/src/redux/user/actions.ts
@@ -68,9 +68,9 @@ export const deleteUser = createAsyncThunk<
   boolean,
   UserDeleteRequest,
   { rejectValue: AxiosError }
->('/user/patchUser', async (userPatch, thunkAPI) => {
+>('/user/deleteUser', async (deleteRequest, thunkAPI) => {
   try {
-    return await api.deleteUser(userPatch);
+    return await api.deleteUser(deleteRequest);
   } catch (err) {
     return thunkAPI.rejectWithValue(err as AxiosError<any>);
   }

--- a/server/src/api/users/users.controller.ts
+++ b/server/src/api/users/users.controller.ts
@@ -44,9 +44,15 @@ export const patchUsers: RouteHandlerFnc = async (ctx) => {
       status = 404;
       return null;
     }
-    if (!(await previous.verifyPassword(currentPassword))) {
-      status = 400;
-      return null;
+    if (email !== undefined || password !== undefined) {
+      // only require password verification for email and password changes
+      if (
+        currentPassword === undefined ||
+        !(await previous.verifyPassword(currentPassword))
+      ) {
+        status = 400;
+        return null;
+      }
     }
     const emailVerified =
       email === undefined || email === previous.email


### PR DESCRIPTION
Previously the default roadmap setting failed

Additional password confirmation is only required for email and password
changes.

Also fixed/renamed what seemed like copy-paste mistake in deleteUser action.