### PR TITLE
Separate CI-workflows for frontend and server

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,25 @@
+name: Frontend tests
+on:
+  pull_request:
+    paths-ignore:
+      # exclude files under /server instead of only including /frontend
+      # as there are shared files outside the frontend directory
+      - 'server/**'
+jobs:
+  build-and-test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "14"
+      - run: cd frontend && yarn install --frozen-lockfile && yarn build && yarn test --passWithNoTests
+        env:
+          CI: false
+          NODE_ENV: "test"
+          CORS_ORIGIN: "http://localhost:3000"
+          SERVER_PORT: "5000"
+          CHOKIDAR_USEPOLLING: "true"
+          REACT_APP_API_BASE_URL: "http://localhost:5000/"

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,5 +1,10 @@
 name: Continuous integration
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      # exclude files under /frontend instead of only including /server
+      # as there are shared files outside the server directory
+      - 'frontend/**'
 jobs:
   build-and-test:
     name: Test
@@ -27,9 +32,8 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "14"
-      - run: cd server && yarn install --frozen-lockfile && yarn test && cd ../frontend && yarn install --frozen-lockfile && yarn build && yarn test --passWithNoTests
-        env: 
-          CI: false
+      - run: cd server && yarn install --frozen-lockfile && yarn test
+        env:
           POSTGRES_DB: "roadmapper-db"
           POSTGRES_USER: "testuser"
           POSTGRES_PASSWORD: "testpassword"


### PR DESCRIPTION
Most pull requests only change one or the other, so it would make sense
to run only the required tests. When there are changes to the shared
files, both workflows will run.