### PR TITLE
Add middleware to check unauthenticated requests

### DIFF
--- a/frontend/src/redux/index.ts
+++ b/frontend/src/redux/index.ts
@@ -1,4 +1,9 @@
-import { combineReducers, configureStore, Action } from '@reduxjs/toolkit';
+import {
+  combineReducers,
+  configureStore,
+  Action,
+  createAction,
+} from '@reduxjs/toolkit';
 import {
   withReduxStateSync,
   createStateSyncMiddleware,
@@ -18,12 +23,15 @@ const appReducer = combineReducers({
   apiV2: apiV2.reducer,
 });
 
+const clearState = createAction('CLEAR_STATE');
+
 const rootReducer: typeof appReducer = (state, action) => {
   if (
+    clearState.match(action) ||
     userActions.logout.fulfilled.match(action) ||
     userActions.deleteUser.fulfilled.match(action)
   ) {
-    // clear all state on logout or account deletion
+    // clear all state on logout, account deletion or explicit request
     return appReducer(undefined, action);
   }
   return appReducer(state, action);
@@ -36,10 +44,29 @@ const stateSyncConfig = {
     !modalsSlice.actions.showModal.match(action),
 };
 
+const isUnauthenticatedError = (action: any) => {
+  if (action.error && action.payload) {
+    const { payload } = action;
+    return payload?.isAxiosError
+      ? payload?.response?.status === 401
+      : payload?.status === 401;
+  }
+  return false;
+};
+
 export const store = configureStore({
   reducer: (withReduxStateSync(rootReducer) as unknown) as typeof appReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
+      ({ dispatch }) => (next) => (action) => {
+        if (isUnauthenticatedError(action)) {
+          // clear the state on any unauthenticated (401) request
+          // as that indicates stale session cookies
+          dispatch(clearState());
+        } else {
+          next(action);
+        }
+      },
       (createStateSyncMiddleware(stateSyncConfig) as unknown) as ReturnType<
         typeof getDefaultMiddleware
       >[0],


### PR DESCRIPTION
This adds a middleware that clears the state on any 401 response that
comes through the redux actions.

There are few functions in the api that are called directly. These are
obviously not handled by this middleware.