### PR TITLE
Taskmap refactor

### DIFF
--- a/frontend/src/components/TaskMap.module.scss
+++ b/frontend/src/components/TaskMap.module.scss
@@ -1,0 +1,30 @@
+@import './../shared.scss';
+
+$ZOOM: var(--zoom, 1);
+
+.taskMap {
+  @extend .layout-column;
+  width: 100%;
+}
+
+.taskName {
+  width: 210px;
+  max-height: 40px;
+  text-align: left;
+  overflow: hidden;
+  word-wrap: break-word;
+
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+
+  &.dragging {
+    width: calc(210px * #{$ZOOM});
+    max-height: calc(40px * #{$ZOOM});
+  }
+}
+
+.measureTaskName {
+  @extend .taskName;
+  visibility: hidden;
+}

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -1,0 +1,258 @@
+import { ReactNode, FC, useEffect, useState } from 'react';
+import { shallowEqual, useSelector, useDispatch } from 'react-redux';
+import { skipToken } from '@reduxjs/toolkit/query/react';
+import ReactFlow, { Controls, OnLoadParams } from 'react-flow-renderer';
+import classNames from 'classnames';
+import InfoIcon from '@mui/icons-material/InfoOutlined';
+import { useTranslation } from 'react-i18next';
+import {
+  chosenRoadmapIdSelector,
+  taskmapPositionSelector,
+} from '../redux/roadmaps/selectors';
+import { roadmapsActions } from '../redux/roadmaps';
+import { Task } from '../redux/roadmaps/types';
+import { StoreDispatchType } from '../redux';
+import {
+  GroupedRelation,
+  getAutolayout,
+  reachable,
+} from '../utils/TaskRelationUtils';
+import { TaskRelationType } from '../../../shared/types/customTypes';
+import { CustomEdge } from './TaskMapEdge';
+import { ConnectionLine } from './TaskMapConnection';
+import { Position, TaskProps } from './TaskMapTask';
+import { TaskGroup } from './TaskMapTaskGroup';
+import { InfoTooltip } from './InfoTooltip';
+import { apiV2 } from '../api/api';
+import css from './TaskMap.module.scss';
+
+const classes = classNames.bind(css);
+
+const CustomNodeComponent: FC<{ data: any }> = ({ data }) => {
+  return <div>{data.label}</div>;
+};
+
+type Group = {
+  id: string;
+  type: 'special';
+  sourcePosition: Position;
+  targetPosition: Position;
+  draggable: boolean;
+  position: {
+    x: number;
+    y: number;
+  };
+  data: {
+    label: ReactNode;
+  };
+};
+
+type Edge = {
+  id: string;
+  type: 'custom';
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+  data: {
+    disableInteraction: boolean;
+  };
+};
+
+export const TaskMap: FC<{
+  taskRelations: GroupedRelation[];
+  draggedTask: number | undefined;
+  selectedTask: Task | undefined;
+  setSelectedTask: (task: Task | undefined) => void;
+  dropUnavailable: Set<string>;
+}> = ({
+  taskRelations,
+  draggedTask,
+  selectedTask,
+  setSelectedTask,
+  dropUnavailable,
+}) => {
+  const { t } = useTranslation();
+  const roadmapId = useSelector(chosenRoadmapIdSelector);
+  const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
+  const [addTaskRelation] = apiV2.useAddTaskRelationMutation();
+  const dispatch = useDispatch<StoreDispatchType>();
+  const mapPosition = useSelector(taskmapPositionSelector, shallowEqual);
+  const [divRef, setDivRef] = useState<HTMLDivElement | null>(null);
+  const [flowElements, setFlowElements] = useState<(Edge | Group)[]>([]);
+  const [flowInstance, setFlowInstance] = useState<OnLoadParams | undefined>();
+  const [unavailable, setUnavailable] = useState<Set<number>>(new Set());
+  const [dragHandle, setDragHandle] = useState<TaskProps['dragHandle']>();
+
+  useEffect(() => {
+    if (!mapPosition && flowInstance && flowElements.length) {
+      // calling flowInstance.fitView() directly doesn't work, this seems to be
+      // a limitation of the library
+      const instance = flowInstance;
+      requestAnimationFrame(() => instance.fitView());
+    }
+  }, [flowInstance, flowElements, mapPosition]);
+
+  useEffect(() => {
+    if (!divRef || taskRelations.length === 0) return;
+
+    const measuredRelations = taskRelations.map((relation, idx) => {
+      // calculate taskgroup height
+      let height = 40;
+
+      relation.synergies.forEach((taskId) => {
+        const task = tasks?.find(({ id }) => id === taskId);
+        if (!task) return;
+        height += 40;
+        // calculate text height
+        divRef.textContent = task.name;
+        height += divRef.offsetHeight;
+        divRef.textContent = '';
+      });
+      return { id: `${idx}`, width: 436, height, ...relation };
+    });
+
+    const graph = getAutolayout(measuredRelations);
+
+    const groups: Group[] = !tasks
+      ? []
+      : measuredRelations.map(({ id, synergies }) => {
+          const node = graph.node(id);
+          return {
+            id,
+            type: 'special',
+            sourcePosition: Position.Right,
+            targetPosition: Position.Left,
+            draggable: false,
+            // dagre coordinates are in the center, calculate top left corner
+            position: {
+              x: node.x - node.width / 2,
+              y: node.y - node.height / 2,
+            },
+            data: {
+              label: (
+                <TaskGroup
+                  listId={id}
+                  taskIds={synergies}
+                  tasks={tasks}
+                  selectedTask={selectedTask}
+                  setSelectedTask={setSelectedTask}
+                  allDependencies={taskRelations.flatMap(
+                    ({ dependencies }) => dependencies,
+                  )}
+                  disableDragging={draggedTask !== undefined}
+                  disableDrop={dropUnavailable.has(id)}
+                  unavailable={unavailable}
+                  dragHandle={dragHandle}
+                />
+              ),
+            },
+          };
+        });
+
+    const edges: Edge[] = measuredRelations.flatMap(({ dependencies }, idx) =>
+      dependencies.flatMap(({ from, to }) => {
+        const targetGroup = measuredRelations.find(({ synergies }) =>
+          synergies.includes(to),
+        );
+        if (!targetGroup) return [];
+        return [
+          {
+            id: `from-${from}-to-${to}`,
+            source: String(idx),
+            sourceHandle: `from-${from}`,
+            target: targetGroup.id,
+            targetHandle: `to-${to}`,
+            type: 'custom',
+            data: { disableInteraction: draggedTask !== undefined },
+          },
+        ];
+      }),
+    );
+
+    setFlowElements([...groups, ...edges]);
+  }, [
+    unavailable,
+    draggedTask,
+    divRef,
+    dragHandle,
+    selectedTask,
+    setSelectedTask,
+    taskRelations,
+    tasks,
+    dropUnavailable,
+  ]);
+
+  const onConnect = async (data: any) => {
+    const { sourceHandle, targetHandle } = data;
+    const type = TaskRelationType.Dependency;
+
+    // Handles are in form 'from-{id}' and 'to-{id}', splitting required
+    const from = Number(sourceHandle.split('-')[1]);
+    const to = Number(targetHandle.split('-')[1]);
+
+    // the handle only accepts valid connections
+    await addTaskRelation({
+      roadmapId: roadmapId!,
+      relation: { from, to, type },
+    }).unwrap();
+  };
+
+  return (
+    <div
+      className={classes(css.taskMap)}
+      style={{
+        ['--zoom' as any]: mapPosition?.zoom || 1,
+      }}
+    >
+      <ReactFlow
+        connectionLineComponent={ConnectionLine}
+        elements={flowElements}
+        nodeTypes={{
+          special: CustomNodeComponent,
+        }}
+        draggable={false}
+        onConnectStart={(_, { nodeId, handleId, handleType }) => {
+          if (!nodeId || !handleId || !handleType) return;
+          const taskId = Number(handleId.split('-')[1]);
+          setUnavailable(reachable(taskId, taskRelations, handleType));
+          const existingConnections = taskRelations.flatMap(
+            ({ dependencies }) =>
+              dependencies.flatMap(({ from, to }) =>
+                from === taskId || to === taskId ? [from, to] : [],
+              ),
+          );
+          setDragHandle({
+            type: handleType,
+            from: taskId,
+            existingConnections,
+          });
+        }}
+        onConnectEnd={() => {
+          setUnavailable(new Set());
+          setDragHandle(undefined);
+        }}
+        onConnect={onConnect}
+        edgeTypes={{
+          custom: CustomEdge,
+        }}
+        onContextMenu={(e) => e.preventDefault()}
+        onLoad={setFlowInstance}
+        defaultZoom={mapPosition?.zoom}
+        defaultPosition={mapPosition && [mapPosition.x, mapPosition.y]}
+        onMove={(tr) => {
+          if (tr) dispatch(roadmapsActions.setTaskmapPosition(tr));
+        }}
+      >
+        <Controls showInteractive={false} showZoom={false}>
+          <InfoTooltip title={t('Taskmap-tooltip')}>
+            <InfoIcon
+              className={classes(css.info, css.tooltipIcon, css.infoIcon)}
+            />
+          </InfoTooltip>
+        </Controls>
+      </ReactFlow>
+      <div ref={setDivRef} className={classes(css.measureTaskName)} />
+    </div>
+  );
+};

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -133,7 +133,7 @@ export const TaskMap: FC<{
               label: (
                 <TaskGroup
                   listId={id}
-                  taskIds={synergies}
+                  taskIds={synergies.sort((a, b) => a - b)} // FIXME: ordering prevents render bugs
                   tasks={tasks}
                   selectedTask={selectedTask}
                   setSelectedTask={setSelectedTask}

--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -1,4 +1,4 @@
-@import '../pages/TaskMapPage.module.scss';
+@import './TaskMap.module.scss';
 
 .singleTask {
   @extend .layout-row;

--- a/frontend/src/components/TaskMapTaskGroup.module.scss
+++ b/frontend/src/components/TaskMapTaskGroup.module.scss
@@ -1,4 +1,4 @@
-@import '../pages/TaskMapPage.module.scss';
+@import './TaskMap.module.scss';
 
 .taskGroup {
   @extend .layout-column;

--- a/frontend/src/components/TaskRatingsText.module.scss
+++ b/frontend/src/components/TaskRatingsText.module.scss
@@ -1,4 +1,4 @@
-@import '../pages/TaskMapPage.module.scss';
+@import './TaskMap.module.scss';
 
 .taskRatingRow {
   display: flex;

--- a/frontend/src/pages/TaskMapPage.module.scss
+++ b/frontend/src/pages/TaskMapPage.module.scss
@@ -1,7 +1,5 @@
 @import '../shared.scss';
 
-$ZOOM: var(--zoom, 1);
-
 .taskmap {
   @extend .layout-column;
   height: 100%;
@@ -29,26 +27,4 @@ $ZOOM: var(--zoom, 1);
   left: 28px;
   bottom: 26px;
   width: 16px;
-}
-
-.taskName {
-  width: 210px;
-  max-height: 40px;
-  text-align: left;
-  overflow: hidden;
-  word-wrap: break-word;
-
-  -webkit-box-orient: vertical;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-
-  &.dragging {
-    width: calc(210px * #{$ZOOM});
-    max-height: calc(40px * #{$ZOOM});
-  }
-}
-
-.measureTaskName {
-  @extend .taskName;
-  visibility: hidden;
 }

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -1,46 +1,30 @@
-import { ReactNode, FC, useEffect, useState } from 'react';
-import { shallowEqual, useSelector, useDispatch } from 'react-redux';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
-import ReactFlow, {
-  Controls,
-  OnLoadParams,
-  ReactFlowProvider,
-} from 'react-flow-renderer';
+import { ReactFlowProvider } from 'react-flow-renderer';
 import {
   DragDropContext,
   DropResult,
   DraggableLocation,
 } from 'react-beautiful-dnd';
 import classNames from 'classnames';
-import InfoIcon from '@mui/icons-material/InfoOutlined';
 import { useTranslation } from 'react-i18next';
-import {
-  chosenRoadmapIdSelector,
-  taskmapPositionSelector,
-} from '../redux/roadmaps/selectors';
-import { roadmapsActions } from '../redux/roadmaps';
+import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { Task } from '../redux/roadmaps/types';
-import { StoreDispatchType } from '../redux';
 import {
   groupTaskRelations,
   GroupedRelation,
-  getAutolayout,
-  reachable,
   blockedGroups,
 } from '../utils/TaskRelationUtils';
 import { getTaskOverviewData } from './TaskOverviewPage';
 import { OverviewContent } from '../components/Overview';
 import { TaskRelationType } from '../../../shared/types/customTypes';
-import { CustomEdge } from '../components/TaskMapEdge';
-import { ConnectionLine } from '../components/TaskMapConnection';
-import { Position, TaskProps } from '../components/TaskMapTask';
 import { move, partition } from '../utils/array';
-import { TaskGroup } from '../components/TaskMapTaskGroup';
-import css from './TaskMapPage.module.scss';
-import { InfoTooltip } from '../components/InfoTooltip';
 import { apiV2 } from '../api/api';
 import { SortableTaskList } from '../components/SortableTaskList';
 import { ExpandableColumn } from '../components/ExpandableColumn';
+import { TaskMap } from '../components/TaskMap';
+import css from './TaskMapPage.module.scss';
 
 const classes = classNames.bind(css);
 
@@ -50,37 +34,6 @@ const copyRelationList = (list: GroupedRelation[]) =>
     dependencies: [...dependencies],
   })) as GroupedRelation[];
 
-const CustomNodeComponent: FC<{ data: any }> = ({ data }) => {
-  return <div>{data.label}</div>;
-};
-
-type Group = {
-  id: string;
-  type: 'special';
-  sourcePosition: Position;
-  targetPosition: Position;
-  draggable: boolean;
-  position: {
-    x: number;
-    y: number;
-  };
-  data: {
-    label: ReactNode;
-  };
-};
-
-type Edge = {
-  id: string;
-  type: 'custom';
-  source: string;
-  sourceHandle: string;
-  target: string;
-  targetHandle: string;
-  data: {
-    disableInteraction: boolean;
-  };
-};
-
 export const TaskMapPage = () => {
   const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
@@ -88,24 +41,15 @@ export const TaskMapPage = () => {
   const { data: relations } = apiV2.useGetTaskRelationsQuery(
     roadmapId ?? skipToken,
   );
-  const [addTaskRelation] = apiV2.useAddTaskRelationMutation();
   const [addSynergy] = apiV2.useAddSynergyRelationsMutation();
-  const mapPosition = useSelector(taskmapPositionSelector, shallowEqual);
-  const dispatch = useDispatch<StoreDispatchType>();
   const [taskRelations, setTaskRelations] = useState<GroupedRelation[]>([]);
   const [stagedTasks, setStagedTasks] = useState<number[]>([]);
   const [unstagedTasks, setUnstagedTasks] = useState<Task[]>([]);
   const [selectedTask, setSelectedTask] = useState<Task | undefined>(undefined);
   const [draggedTask, setDraggedTask] = useState<number | undefined>();
-  const [divRef, setDivRef] = useState<HTMLDivElement | null>(null);
-  const [flowElements, setFlowElements] = useState<(Edge | Group)[]>([]);
-  const [flowInstance, setFlowInstance] = useState<OnLoadParams | undefined>();
-  const [unavailable, setUnavailable] = useState<Set<number>>(new Set());
   const [dropUnavailable, setDropUnavailable] = useState<Set<string>>(
     new Set(),
   );
-  const [dragHandle, setDragHandle] = useState<TaskProps['dragHandle']>();
-
   const [expandUnstaged, setExpandUnstaged] = useState(false);
 
   useEffect(() => {
@@ -134,119 +78,6 @@ export const TaskMapPage = () => {
       ),
     );
   }, [relations, tasks, stagedTasks]);
-
-  useEffect(() => {
-    if (!mapPosition && flowInstance && flowElements.length) {
-      // calling flowInstance.fitView() directly doesn't work, this seems to be
-      // a limitation of the library
-      const instance = flowInstance;
-      requestAnimationFrame(() => instance.fitView());
-    }
-  }, [flowInstance, flowElements, mapPosition]);
-
-  useEffect(() => {
-    if (!divRef || taskRelations.length === 0) return;
-
-    const measuredRelations = taskRelations.map((relation, idx) => {
-      // calculate taskgroup height
-      let height = 40;
-
-      relation.synergies.forEach((taskId) => {
-        const task = tasks?.find(({ id }) => id === taskId);
-        if (!task) return;
-        height += 40;
-        // calculate text height
-        divRef.textContent = task.name;
-        height += divRef.offsetHeight;
-        divRef.textContent = '';
-      });
-      return { id: `${idx}`, width: 436, height, ...relation };
-    });
-
-    const graph = getAutolayout(measuredRelations);
-
-    const groups: Group[] = !tasks
-      ? []
-      : measuredRelations.map(({ id, synergies }) => {
-          const node = graph.node(id);
-          return {
-            id,
-            type: 'special',
-            sourcePosition: Position.Right,
-            targetPosition: Position.Left,
-            draggable: false,
-            // dagre coordinates are in the center, calculate top left corner
-            position: {
-              x: node.x - node.width / 2,
-              y: node.y - node.height / 2,
-            },
-            data: {
-              label: (
-                <TaskGroup
-                  listId={id}
-                  taskIds={synergies}
-                  tasks={tasks}
-                  selectedTask={selectedTask}
-                  setSelectedTask={setSelectedTask}
-                  allDependencies={taskRelations.flatMap(
-                    ({ dependencies }) => dependencies,
-                  )}
-                  disableDragging={draggedTask !== undefined}
-                  disableDrop={dropUnavailable.has(id)}
-                  unavailable={unavailable}
-                  dragHandle={dragHandle}
-                />
-              ),
-            },
-          };
-        });
-
-    const edges: Edge[] = measuredRelations.flatMap(({ dependencies }, idx) =>
-      dependencies.flatMap(({ from, to }) => {
-        const targetGroup = measuredRelations.find(({ synergies }) =>
-          synergies.includes(to),
-        );
-        if (!targetGroup) return [];
-        return [
-          {
-            id: `from-${from}-to-${to}`,
-            source: String(idx),
-            sourceHandle: `from-${from}`,
-            target: targetGroup.id,
-            targetHandle: `to-${to}`,
-            type: 'custom',
-            data: { disableInteraction: draggedTask !== undefined },
-          },
-        ];
-      }),
-    );
-
-    setFlowElements([...groups, ...edges]);
-  }, [
-    unavailable,
-    draggedTask,
-    divRef,
-    dragHandle,
-    selectedTask,
-    taskRelations,
-    tasks,
-    dropUnavailable,
-  ]);
-
-  const onConnect = async (data: any) => {
-    const { sourceHandle, targetHandle } = data;
-    const type = TaskRelationType.Dependency;
-
-    // Handles are in form 'from-{id}' and 'to-{id}', splitting required
-    const from = Number(sourceHandle.split('-')[1]);
-    const to = Number(targetHandle.split('-')[1]);
-
-    // the handle only accepts valid connections
-    await addTaskRelation({
-      roadmapId: roadmapId!,
-      relation: { from, to, type },
-    }).unwrap();
-  };
 
   const addSynergyRelations = (from: number, to: number[]) =>
     addSynergy({ roadmapId: roadmapId!, from, to }).unwrap();
@@ -347,13 +178,7 @@ export const TaskMapPage = () => {
   };
 
   return (
-    <div
-      id="taskmap"
-      className={classes(css.taskmap, css.grow)}
-      style={{
-        ['--zoom' as any]: mapPosition?.zoom || 1,
-      }}
-    >
+    <div id="taskmap" className={classes(css.taskmap, css.grow)}>
       <DragDropContext
         onDragEnd={onDragEnd}
         onDragStart={({ draggableId }) => {
@@ -389,53 +214,13 @@ export const TaskMapPage = () => {
             />
           </ExpandableColumn>
           <ReactFlowProvider>
-            <ReactFlow
-              connectionLineComponent={ConnectionLine}
-              elements={flowElements}
-              nodeTypes={{
-                special: CustomNodeComponent,
-              }}
-              draggable={false}
-              onConnectStart={(_, { nodeId, handleId, handleType }) => {
-                if (!nodeId || !handleId || !handleType) return;
-                const taskId = Number(handleId.split('-')[1]);
-                setUnavailable(reachable(taskId, taskRelations, handleType));
-                const existingConnections = taskRelations.flatMap(
-                  ({ dependencies }) =>
-                    dependencies.flatMap(({ from, to }) =>
-                      from === taskId || to === taskId ? [from, to] : [],
-                    ),
-                );
-                setDragHandle({
-                  type: handleType,
-                  from: taskId,
-                  existingConnections,
-                });
-              }}
-              onConnectEnd={() => {
-                setUnavailable(new Set());
-                setDragHandle(undefined);
-              }}
-              onConnect={onConnect}
-              edgeTypes={{
-                custom: CustomEdge,
-              }}
-              onContextMenu={(e) => e.preventDefault()}
-              onLoad={setFlowInstance}
-              defaultZoom={mapPosition?.zoom}
-              defaultPosition={mapPosition && [mapPosition.x, mapPosition.y]}
-              onMove={(tr) => {
-                if (tr) dispatch(roadmapsActions.setTaskmapPosition(tr));
-              }}
-            >
-              <Controls showInteractive={false} showZoom={false}>
-                <InfoTooltip title={t('Taskmap-tooltip')}>
-                  <InfoIcon
-                    className={classes(css.info, css.tooltipIcon, css.infoIcon)}
-                  />
-                </InfoTooltip>
-              </Controls>
-            </ReactFlow>
+            <TaskMap
+              taskRelations={taskRelations}
+              draggedTask={draggedTask}
+              selectedTask={selectedTask}
+              setSelectedTask={setSelectedTask}
+              dropUnavailable={dropUnavailable}
+            />
           </ReactFlowProvider>
         </div>
         {selectedTask && (
@@ -444,7 +229,6 @@ export const TaskMapPage = () => {
           </div>
         )}
       </DragDropContext>
-      <div ref={setDivRef} className={classes(css.measureTaskName)} />
     </div>
   );
 };


### PR DESCRIPTION
Separates TaskMap dnd and react-flow logic. https://trello.com/c/8RGjY9As/503-improve-taskmap-code-readability

- Move ReactFlow to its own component to separate most drag-n-drop and react-flow logic.

Possible use of react-flow's useZoomPanHelper-hook is taken into consideration in this decision.
(useZoomPanHelper provides utility functions for react-flow's viewport, could be used to move canvas on drag)
useZoomPanHelper needs to be inside context of ReactFlowProvider and being a hook, it needs to be used in a component.


- Also encountered the taskmap edge-render bug again (moving a task to another group and the edges not updating correctly). Added the old fix back in.