### PR TITLE
Fix loading cursor on task drag

### DIFF
--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -14,10 +14,6 @@
   position: relative;
   align-items: center;
 
-  &.unavailable {
-    filter: grayscale(100%) opacity(20%);
-  }
-
   button {
     visibility: hidden;
     padding: 0;
@@ -40,6 +36,7 @@
 
     &.draggingOutside {
       box-shadow: 0px 0px 30px rgba($color: $COLOR_AZURE, $alpha: 0.3);
+      cursor: -webkit-grabbing;
     }
 
     .doneIcon {
@@ -48,7 +45,7 @@
       height: calc(1em * #{$ZOOM});
     }
   }
-  &.loading:not(.dragging) {
+  &.loading:not(.dragging, .draggingOutside) {
     cursor: wait;
   }
 }

--- a/frontend/src/components/TaskMapTaskGroup.module.scss
+++ b/frontend/src/components/TaskMapTaskGroup.module.scss
@@ -7,13 +7,16 @@
   width: 405px;
   background-color: rgba($COLOR_CLOUD, 0.75);
   border-radius: 10px;
-  cursor: default;
+
+  &:not(.unavailable) {
+    cursor: default;
+  }
 
   &.unavailable {
     filter: grayscale(100%) opacity(20%);
   }
 
-  &.loading:not(.highlight) {
+  &.loading:not(.highlight, .unavailable) {
     cursor: wait;
   }
 


### PR DESCRIPTION
I had trouble with implementing cursor: not-allowed on unavailable tasks/groups. It seemed to work only sometimes and persist when leaving to hover elsewhere.

I ended up only fixing the incorrectly shown loading cursor when dragging. I'll leave the not-allowed cursor as a separate task.