### PR TITLE
Correctly display unrated tasks count in team members list

### DIFF
--- a/frontend/src/components/TableTeamMemberRow.tsx
+++ b/frontend/src/components/TableTeamMemberRow.tsx
@@ -15,7 +15,7 @@ import { userInfoSelector } from '../redux/user/selectors';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes, modalLink } from './modals/types';
 import { getType } from '../utils/UserUtils';
-import { unratedTasksAmount } from '../utils/TaskUtils';
+import { unratedTasksByUserCount } from '../utils/TaskUtils';
 import { apiV2 } from '../api/api';
 
 const classes = classNames.bind(css);
@@ -34,17 +34,17 @@ export const TableTeamMemberRow: FC<TableRowProps> = ({ member }) => {
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const [unratedAmount, setUnratedAmount] = useState(0);
   const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
-  const { data: users } = apiV2.useGetRoadmapUsersQuery(roadmapId ?? skipToken);
   const { data: customers } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,
   );
 
   useEffect(() => {
-    if (roadmapId && tasks)
+    if (roadmapId && tasks && customers) {
       setUnratedAmount(
-        unratedTasksAmount(member, roadmapId, tasks, users, customers),
+        unratedTasksByUserCount(tasks, member, roadmapId, customers),
       );
-  }, [customers, member, roadmapId, tasks, users]);
+    }
+  }, [customers, member, roadmapId, tasks]);
 
   const deleteUserClicked = (e: MouseEvent) => {
     e.preventDefault();

--- a/frontend/src/components/TeamMemberListTable.tsx
+++ b/frontend/src/components/TeamMemberListTable.tsx
@@ -25,17 +25,15 @@ export const TeamMemberList: FC<{
     roadmapId ?? skipToken,
   );
   const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
-  const { data: users } = apiV2.useGetRoadmapUsersQuery(roadmapId ?? skipToken);
   const { data: customers } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,
   );
 
   const [sort, sorting] = useSorting(
-    useMemo(() => userSort(roadmapId, tasks, users, customers), [
+    useMemo(() => userSort(roadmapId, tasks, customers), [
       customers,
       roadmapId,
       tasks,
-      users,
     ]),
   );
 

--- a/frontend/src/utils/SortRoadmapUserUtils.ts
+++ b/frontend/src/utils/SortRoadmapUserUtils.ts
@@ -1,6 +1,6 @@
 import { RoadmapUser, Customer, Task } from '../redux/roadmaps/types';
 import { RoleType } from '../../../shared/types/customTypes';
-import { unratedTasksAmount } from './TaskUtils';
+import { unratedTasksByUserCount } from './TaskUtils';
 import { SortBy, sortKeyLocale, sortKeyNumeric } from './SortUtils';
 
 export enum UserSortingTypes {
@@ -12,7 +12,6 @@ export enum UserSortingTypes {
 export const userSort = (
   roadmapId?: number,
   tasks?: Task[],
-  users?: RoadmapUser[],
   customers?: Customer[],
 ) => (type: UserSortingTypes | undefined): SortBy<RoadmapUser> => {
   switch (type) {
@@ -21,10 +20,10 @@ export const userSort = (
     case UserSortingTypes.SORT_ROLE:
       return sortKeyLocale((user) => RoleType[user.type]);
     case UserSortingTypes.SORT_UNRATED:
-      return roadmapId === undefined
+      return !roadmapId || !tasks || !customers
         ? undefined
         : sortKeyNumeric((user) =>
-            unratedTasksAmount(user, roadmapId, tasks ?? [], users, customers),
+            unratedTasksByUserCount(tasks, user, roadmapId, customers),
           );
     default:
       break;

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -278,6 +278,15 @@ export const awaitsUserRatings = <T extends UserInfo | RoadmapUser>(
   return not(ratedByUser(user));
 };
 
+export const unratedTasksByUserCount = (
+  tasks: Task[],
+  user: RoadmapUser,
+  roadmapId: number,
+  customers: Customer[],
+) => {
+  return tasks?.filter(awaitsUserRatings(user, roadmapId, customers)).length;
+};
+
 export const hasMissingRatings = (
   users: RoadmapUser[] = [],
   customers: Customer[] = [],


### PR DESCRIPTION
Previously the row displayed the count of tasks filtered by `isUnrated`, effectively displaying the # of unrated tasks missing from representatives (the count that is used in PO's dashboard and tasklist) instead of the count of the tasks unrated specifically by the PO themself.