### PR TITLE
Fix task list search

### DIFF
--- a/frontend/src/pages/TaskListPage.tsx
+++ b/frontend/src/pages/TaskListPage.tsx
@@ -102,8 +102,8 @@ export const TaskListPage = () => {
   const filter = taskFilter(searchFilter, userInfo);
   const predicate = (task: Task) =>
     (!filter || filter(task)) &&
-    (task.name.includes(searchString) ||
-      task.description.includes(searchString));
+    (task.name.toLowerCase().includes(searchString) ||
+      task.description.toLowerCase().includes(searchString));
 
   return (
     <>


### PR DESCRIPTION
With the new search field component, the search phrase is always
lowercase. This made it impossible to find words with non-lowercase
letters.