### PR TITLE
Customer ratings without user or with old representatives

### DIFF
--- a/frontend/src/components/RatingTable.tsx
+++ b/frontend/src/components/RatingTable.tsx
@@ -34,7 +34,7 @@ const numFormat = new Intl.NumberFormat(undefined, {
 export type RatingRow = FC<{
   rating: Taskrating;
   style?: CSSProperties;
-  userId: number;
+  user: UserInfo;
   onEdit: (e: MouseEvent) => void;
 }>;
 
@@ -137,7 +137,7 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
           <Row
             style={style}
             rating={ratings[index]}
-            userId={userInfo.id}
+            user={userInfo}
             onEdit={openRateModal}
           />
         )}

--- a/frontend/src/components/RatingTableComplexity.tsx
+++ b/frontend/src/components/RatingTableComplexity.tsx
@@ -19,16 +19,16 @@ const numFormat = new Intl.NumberFormat(undefined, {
 const TableComplexityRatingRow: RatingRow = ({
   rating,
   style,
-  userId,
+  user,
   onEdit,
 }) => {
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const { data: user } = apiV2.useGetRoadmapUsersQuery(
+  const { data: createdBy } = apiV2.useGetRoadmapUsersQuery(
     roadmapId ?? skipToken,
     selectById(rating.createdByUser),
   );
 
-  if (!user) return null;
+  if (!createdBy) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>
@@ -36,9 +36,9 @@ const TableComplexityRatingRow: RatingRow = ({
         <div className={classes(css.roleIcon)}>
           <BuildSharpIcon fontSize="small" />
         </div>
-        <div className={classes(css.name)}>{user.email}</div>
+        <div className={classes(css.name)}>{createdBy.email}</div>
         <div className={classes(css.rightSide)}>
-          {user.id === userId && (
+          {createdBy.id === user.id && (
             <EditButton fontSize="medium" onClick={onEdit} />
           )}
           <div className={classes(css.value)}>

--- a/frontend/src/components/RatingTableComplexity.tsx
+++ b/frontend/src/components/RatingTableComplexity.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import BuildSharpIcon from '@mui/icons-material/BuildSharp';
 import { useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
+import { useTranslation } from 'react-i18next';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { ratingTable, RatingRow } from './RatingTable';
 import { EditButton } from './forms/SvgButton';
@@ -22,13 +23,12 @@ const TableComplexityRatingRow: RatingRow = ({
   user,
   onEdit,
 }) => {
+  const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: createdBy } = apiV2.useGetRoadmapUsersQuery(
     roadmapId ?? skipToken,
     selectById(rating.createdByUser),
   );
-
-  if (!createdBy) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>
@@ -36,9 +36,11 @@ const TableComplexityRatingRow: RatingRow = ({
         <div className={classes(css.roleIcon)}>
           <BuildSharpIcon fontSize="small" />
         </div>
-        <div className={classes(css.name)}>{createdBy.email}</div>
+        <div className={classes(css.name)}>
+          {createdBy?.email ?? `<${t('deleted account')}>`}
+        </div>
         <div className={classes(css.rightSide)}>
-          {createdBy.id === user.id && (
+          {rating.createdByUser === user.id && (
             <EditButton fontSize="medium" onClick={onEdit} />
           )}
           <div className={classes(css.value)}>

--- a/frontend/src/components/RatingTableValue.tsx
+++ b/frontend/src/components/RatingTableValue.tsx
@@ -16,9 +16,9 @@ const numFormat = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 1,
 });
 
-const TableValueRatingRow: RatingRow = ({ rating, style, userId, onEdit }) => {
+const TableValueRatingRow: RatingRow = ({ rating, style, user, onEdit }) => {
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const { data: user } = apiV2.useGetRoadmapUsersQuery(
+  const { data: createdBy } = apiV2.useGetRoadmapUsersQuery(
     roadmapId ?? skipToken,
     selectById(rating.createdByUser),
   );
@@ -27,7 +27,7 @@ const TableValueRatingRow: RatingRow = ({ rating, style, userId, onEdit }) => {
     selectById(rating.forCustomer),
   );
 
-  if (!user || !customer) return null;
+  if (!createdBy || !customer) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>
@@ -37,12 +37,15 @@ const TableValueRatingRow: RatingRow = ({ rating, style, userId, onEdit }) => {
             <Dot fill={customer.color} />
             <div className={classes(css.name)}>{customer.name}</div>
           </div>
-          <div className={classes(css.bottomRow, css.name)}>{user.email}</div>
+          <div className={classes(css.bottomRow, css.name)}>
+            {createdBy.email}
+          </div>
         </div>
         <div className={classes(css.rightSide)}>
-          {user.id === userId && (
-            <EditButton fontSize="medium" onClick={onEdit} />
-          )}
+          {createdBy.id === user.id &&
+            user.representativeFor?.some(
+              ({ id }) => id === rating.forCustomer,
+            ) && <EditButton fontSize="medium" onClick={onEdit} />}
           <div className={classes(css.value)}>
             {numFormat.format(rating.value)}
           </div>

--- a/frontend/src/components/RatingTableValue.tsx
+++ b/frontend/src/components/RatingTableValue.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
+import { useTranslation } from 'react-i18next';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { ratingTable, RatingRow } from './RatingTable';
 import { EditButton } from './forms/SvgButton';
@@ -17,6 +18,7 @@ const numFormat = new Intl.NumberFormat(undefined, {
 });
 
 const TableValueRatingRow: RatingRow = ({ rating, style, user, onEdit }) => {
+  const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: createdBy } = apiV2.useGetRoadmapUsersQuery(
     roadmapId ?? skipToken,
@@ -27,7 +29,7 @@ const TableValueRatingRow: RatingRow = ({ rating, style, user, onEdit }) => {
     selectById(rating.forCustomer),
   );
 
-  if (!createdBy || !customer) return null;
+  if (!customer) return null;
 
   return (
     <div style={style} className={classes(css.ratingRow)}>
@@ -38,11 +40,11 @@ const TableValueRatingRow: RatingRow = ({ rating, style, user, onEdit }) => {
             <div className={classes(css.name)}>{customer.name}</div>
           </div>
           <div className={classes(css.bottomRow, css.name)}>
-            {createdBy.email}
+            {createdBy?.email ?? `<${t('deleted account')}>`}
           </div>
         </div>
         <div className={classes(css.rightSide)}>
-          {createdBy.id === user.id &&
+          {rating.createdByUser === user.id &&
             user.representativeFor?.some(
               ({ id }) => id === rating.forCustomer,
             ) && <EditButton fontSize="medium" onClick={onEdit} />}

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -346,5 +346,6 @@ export const english = {
     'Email service error': 'Email service error',
     'This email doesn’t exist': 'This email doesn’t exist',
     You: 'You',
+    'deleted account': 'deleted account',
   },
 };


### PR DESCRIPTION
Fixes the handling of ratings user has given for a customer the user no longer represents.

Correctly shows ratings from users that have left the roadmap.

Ratings for a customer are already deleted, as they should, when the associated customer is deleted.

Todo for another issue: decide what should happen to ratings when the associated user account is deleted.