### PR TITLE
Add taskmap handle style effects

### DIFF
--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -67,6 +67,10 @@
   width: 17px !important;
   background-color: $COLOR_WHITE !important;
 
+  &.connecting:not(.connectable, .connectStart) {
+    filter: grayscale(100%) !important;
+  }
+
   &.dragging {
     height: calc(17px * #{$ZOOM}) !important;
     width: calc(17px * #{$ZOOM}) !important;
@@ -80,11 +84,20 @@
   border: 2px solid $COLOR_ORANGE !important;
 
   &.filled {
-    background-color: lighten($COLOR_ORANGE, 20%) !important;
+    background-color: lighten($COLOR_ORANGE, 25%) !important;
+  }
+
+  &:hover:not(.connectable),
+  &.connectStart {
+    background-color: lighten($COLOR_ORANGE, 8%) !important;
   }
 
   &.connectable {
-    box-shadow: 0 0 10px 4px $COLOR_ORANGE !important;
+    box-shadow: 0 0 10px 4px lighten($COLOR_ORANGE, 20%) !important;
+
+    &:hover {
+      box-shadow: 0 0 10px 4px $COLOR_ORANGE !important;
+    }
   }
 }
 
@@ -94,11 +107,20 @@
   border: 2px solid $COLOR_FOREST !important;
 
   &.filled {
-    background-color: lighten($COLOR_FOREST, 20%) !important;
+    background-color: lighten($COLOR_FOREST, 25%) !important;
+  }
+
+  &:hover:not(.connectable),
+  &.connectStart {
+    background-color: lighten($COLOR_FOREST, 7%) !important;
   }
 
   &.connectable {
-    box-shadow: 0 0 10px 4px $COLOR_FOREST !important;
+    box-shadow: 0 0 10px 4px lighten($COLOR_FOREST, 25%) !important;
+
+    &:hover {
+      box-shadow: 0 0 10px 4px lighten($COLOR_FOREST, 2%) !important;
+    }
   }
 }
 

--- a/frontend/src/components/TaskMapTask.tsx
+++ b/frontend/src/components/TaskMapTask.tsx
@@ -77,6 +77,9 @@ const SingleTask: FC<
             [css.filled]: checked[key],
             [css.dragging]: isDragging,
             [css.connectable]: connectable,
+            [css.connecting]: !!dragHandle,
+            [css.connectStart]:
+              dragHandle?.from === taskId && dragHandle.type === type,
           })}
           id={`${key}-${taskId}`}
           type={type}


### PR DESCRIPTION
https://trello.com/c/nTXYc0AF/365-task-map-handleihin-onclick-hoverille-effektit
It looks like this may be a expired task. If this is not an improvement, lets close the pr


- Add hover effect to handles (the same effect is preserved when user starts connecting from the handle)
- Unconnectable handles are grayed out
- Connectable handles have a hover effect