### PR TITLE
Fix StepForm bug

### DIFF
--- a/frontend/src/components/forms/StepForm.tsx
+++ b/frontend/src/components/forms/StepForm.tsx
@@ -82,7 +82,7 @@ export const StepForm: FC<{
   };
 
   const handleCancel = () => {
-    steps[step - 1].onPreviousStepClick?.();
+    steps[step - 1]?.onPreviousStepClick?.();
     if (step === 0) {
       setStep(previousStep);
       return;


### PR DESCRIPTION
Fix bug: if user presses "No, go back" in the cancel confirmation, the
application would crash due to a missing undefined check.