### PR TITLE
Make taskrating's user reference nullable

### DIFF
--- a/server/src/migrations/20220310110218_nullableUserReferenceInTaskrating.ts
+++ b/server/src/migrations/20220310110218_nullableUserReferenceInTaskrating.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .alterTable('taskratings', (table) => {
+      table.dropForeign(['createdByUser']);
+      table.dropIndex(['createdByUser']);
+      table
+        .integer('createdByUser')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('SET NULL')
+        .index()
+        .alter();
+    })
+    .raw(
+      // The unique constraint is ingored on rows where any of
+      // the columns in the constraint are null. This allows setting
+      // deleted user references to NULL, but requires additional
+      // constraint on developer ratings, as "forCustomer" is always
+      // NULL for those.
+      `
+      CREATE UNIQUE INDEX unique_developer_ratings
+      ON taskratings("parentTask", "createdByUser", dimension)
+      WHERE "forCustomer" IS NULL;
+      `,
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('taskratings', (table) => {
+    table.dropForeign(['createdByUser']);
+    table.dropIndex(['createdByUser']);
+    table.dropIndex('', 'unique_developer_ratings');
+    table
+      .integer('createdByUser')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE')
+      .index()
+      .alter();
+  });
+}


### PR DESCRIPTION
This changes `onDelete` from `CASCADE` to `SET NULL` for `createdByUser`
foreign key, allowing ratings to remain when the user account is
deleted.

This also adds unique constraint for developer ratings, which were
previously not checked, as one column (`forCustomer`) on the index was
always NULL.