### PR TITLE
Task status & trello board mapping schema

### DIFF
--- a/frontend/src/components/EditableText.module.scss
+++ b/frontend/src/components/EditableText.module.scss
@@ -22,11 +22,15 @@
   &.bold {
     @extend .typography-body-bold;
   }
-  &.unordered {
+  &.NOT_STARTED {
     @extend .typography-pre-title;
   }
-  &.completed {
-    @extend .unordered;
+  &.IN_PROGRESS {
+    @extend .NOT_STARTED;
+    color: $COLOR_ORANGE;
+  }
+  &.COMPLETED {
+    @extend .NOT_STARTED;
     color: $COLOR_FOREST;
   }
 }

--- a/frontend/src/components/Overview.module.scss
+++ b/frontend/src/components/Overview.module.scss
@@ -89,11 +89,15 @@
     &.bold {
       @extend .typography-body-bold;
     }
-    &.unordered {
+    &.NOT_STARTED {
       @extend .typography-pre-title;
     }
-    &.completed {
-      @extend .unordered;
+    &.IN_PROGRESS {
+      @extend .NOT_STARTED;
+      color: $COLOR_ORANGE;
+    }
+    &.COMPLETED {
+      @extend .NOT_STARTED;
       color: $COLOR_FOREST;
     }
     &.clientGap {

--- a/frontend/src/components/RoadmapCompletionMeter.tsx
+++ b/frontend/src/components/RoadmapCompletionMeter.tsx
@@ -7,6 +7,7 @@ import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { partition } from '../utils/array';
 import css from './RoadmapCompletionMeter.module.scss';
 import { apiV2 } from '../api/api';
+import { TaskStatus } from '../../../shared/types/customTypes';
 
 const classes = classNames.bind(css);
 
@@ -16,7 +17,7 @@ export const RoadmapCompletionMeter = () => {
 
   const [completed, uncompleted] = partition(
     tasks ?? [],
-    (t) => t.completed,
+    (t) => t.status === TaskStatus.COMPLETED,
   ).map((a) => a.length);
 
   const getCompletionPercent = () => {

--- a/frontend/src/components/TaskMapTask.tsx
+++ b/frontend/src/components/TaskMapTask.tsx
@@ -7,6 +7,7 @@ import DoneAllIcon from '@mui/icons-material/DoneAll';
 import { Task } from '../redux/roadmaps/types';
 import { TaskRatingsText } from './TaskRatingsText';
 import css from './TaskMapTask.module.scss';
+import { TaskStatus } from '../../../shared/types/customTypes';
 
 const classes = classNames.bind(css);
 
@@ -109,7 +110,9 @@ const SingleTask: FC<
       {...provided.dragHandleProps}
     >
       {handle('target')}
-      {task.completed && <DoneAllIcon className={classes(css.doneIcon)} />}
+      {task.status === TaskStatus.COMPLETED && (
+        <DoneAllIcon className={classes(css.doneIcon)} />
+      )}
       <div
         className={classes(css.taskName, {
           [css.dragging]: isDragging,

--- a/frontend/src/components/TaskRelationTable.tsx
+++ b/frontend/src/components/TaskRelationTable.tsx
@@ -19,6 +19,7 @@ import {
 import { TaskRatingsText } from './TaskRatingsText';
 import css from './TaskRelationTable.module.scss';
 import { apiV2 } from '../api/api';
+import { TaskStatus } from '../../../shared/types/customTypes';
 
 const classes = classNames.bind(css);
 
@@ -46,7 +47,9 @@ const RelationRow: FC<{
       style={style}
       className={classes(css.task)}
     >
-      {task.completed && <DoneAllIcon className={classes(css.doneIcon)} />}
+      {task.status === TaskStatus.COMPLETED && (
+        <DoneAllIcon className={classes(css.doneIcon)} />
+      )}
       <div className={classes(css.taskName)}>{task.name}</div>
       <div className={classes(css.taskRatingTexts)}>
         <TaskRatingsText task={task} largeIcons />

--- a/frontend/src/components/TaskTable.module.scss
+++ b/frontend/src/components/TaskTable.module.scss
@@ -24,12 +24,16 @@
   color: $COLOR_BLACK60;
 }
 
-.statusComplete {
+.COMPLETED {
   @extend .typography-pre-title;
   color: $COLOR_FOREST;
 }
 
-.statusUnordered {
+.IN_PROGRESS {
+  @extend .typography-pre-title;
+  color: $COLOR_ORANGE;
+}
+.NOT_STARTED {
   @extend .typography-pre-title;
   color: $COLOR_BLACK100;
 }

--- a/frontend/src/components/TaskTableRated.tsx
+++ b/frontend/src/components/TaskTableRated.tsx
@@ -10,6 +10,7 @@ import {
   SortingTypes,
   valueAndComplexitySummary,
   taskSort,
+  taskStatusToText,
 } from '../utils/TaskUtils';
 import { table, TableRow } from './Table';
 import css from './TaskTable.module.scss';
@@ -68,15 +69,9 @@ const TableRatedTaskRow: TableRow<Task> = ({ item: task, style }) => {
         <div>{numFormat.format(value.total)}</div>
         <div>{numFormat.format(complexity.total)}</div>
         <div>
-          {task.status === TaskStatus.COMPLETED ? (
-            <span className={classes(css.statusComplete)}>
-              <Trans i18nKey="Completed" />
-            </span>
-          ) : (
-            <span className={classes(css.statusUnordered)}>
-              <Trans i18nKey="Unordered" />
-            </span>
-          )}
+          <span className={classes(css[TaskStatus[task.status]])}>
+            <Trans i18nKey={taskStatusToText(task.status)} />
+          </span>
         </div>
         <div className={classes(css.ratedButtons)}>
           {type === RoleType.Admin && (

--- a/frontend/src/components/TaskTableRated.tsx
+++ b/frontend/src/components/TaskTableRated.tsx
@@ -18,7 +18,7 @@ import { DeleteButton } from './forms/SvgButton';
 import { StoreDispatchType } from '../redux';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from './modals/types';
-import { RoleType } from '../../../shared/types/customTypes';
+import { RoleType, TaskStatus } from '../../../shared/types/customTypes';
 import { userRoleSelector } from '../redux/user/selectors';
 
 const classes = classNames.bind(css);
@@ -54,11 +54,13 @@ const TableRatedTaskRow: TableRow<Task> = ({ item: task, style }) => {
       <div
         style={style}
         className={classes(css.virtualizedTableRow, {
-          [css.completedRow]: task.completed,
+          [css.completedRow]: task.status === TaskStatus.COMPLETED,
         })}
       >
         <div className={classes(css.ratedTitle)}>
-          {task.completed && <DoneAllIcon className={classes(css.doneIcon)} />}
+          {task.status === TaskStatus.COMPLETED && (
+            <DoneAllIcon className={classes(css.doneIcon)} />
+          )}
           {task.name}
         </div>
         <div>{numFormat.format(value.avg)}</div>
@@ -66,7 +68,7 @@ const TableRatedTaskRow: TableRow<Task> = ({ item: task, style }) => {
         <div>{numFormat.format(value.total)}</div>
         <div>{numFormat.format(complexity.total)}</div>
         <div>
-          {task.completed ? (
+          {task.status === TaskStatus.COMPLETED ? (
             <span className={classes(css.statusComplete)}>
               <Trans i18nKey="Completed" />
             </span>

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -32,6 +32,8 @@ export const english = {
     'Rated by me': 'Rated by me',
     'Created by': 'Created by',
     Completed: 'Completed',
+    'In progress': 'In progress',
+    'Not started': 'Not started',
     'Not completed': 'Not completed',
     'Rate task': 'Rate task',
     'Edit ratings': 'Edit ratings',

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -6,7 +6,7 @@ import i18n from 'i18next';
 import { useSelector, shallowEqual } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useParams, useHistory, Redirect } from 'react-router-dom';
-import { Permission } from '../../../shared/types/customTypes';
+import { Permission, TaskStatus } from '../../../shared/types/customTypes';
 import {
   valueAndComplexitySummary,
   getRatingsByType,
@@ -79,8 +79,9 @@ export const getTaskOverviewData = (task: Task, editable: boolean) => {
       {
         label: i18n.t('Status'),
         keyName: 'completed',
-        value: task.completed ? 'Completed' : 'Unordered',
-        format: task.completed ? 'completed' : 'unordered',
+        value: task.status === TaskStatus.COMPLETED ? 'Completed' : 'Unordered',
+        format:
+          task.status === TaskStatus.COMPLETED ? 'completed' : 'unordered',
         editable: false,
       },
     ],

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -10,6 +10,7 @@ import { Permission, TaskStatus } from '../../../shared/types/customTypes';
 import {
   valueAndComplexitySummary,
   getRatingsByType,
+  taskStatusToText,
 } from '../utils/TaskUtils';
 import { BusinessIcon, WorkRoundIcon } from '../components/RoleIcons';
 import { userRoleSelector } from '../redux/user/selectors';
@@ -52,6 +53,7 @@ export const getTaskOverviewData = (task: Task, editable: boolean) => {
       children: <WorkRoundIcon color={colors.black100} />,
     },
   ];
+
   const data = [
     [
       {
@@ -78,10 +80,9 @@ export const getTaskOverviewData = (task: Task, editable: boolean) => {
       },
       {
         label: i18n.t('Status'),
-        keyName: 'completed',
-        value: task.status === TaskStatus.COMPLETED ? 'Completed' : 'Unordered',
-        format:
-          task.status === TaskStatus.COMPLETED ? 'completed' : 'unordered',
+        keyName: 'status',
+        value: taskStatusToText(task.status),
+        format: TaskStatus[task.status],
         editable: false,
       },
     ],

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -2,6 +2,7 @@ import {
   TaskRatingDimension,
   RoleType,
   TaskRelationType,
+  TaskStatus,
 } from '../../../../shared/types/customTypes';
 
 export interface RoadmapsState {
@@ -103,7 +104,7 @@ export interface Task {
   description: string;
   roadmapId: number;
   createdAt: string;
-  completed: boolean;
+  status: TaskStatus;
   ratings: Taskrating[];
   createdByUser: number;
 }

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -55,6 +55,25 @@ class RatingsSummary {
   }
 }
 
+export const taskStatusToText = (status: TaskStatus | number) => {
+  switch (status) {
+    case TaskStatus.NOT_STARTED:
+      return 'Not started';
+    case TaskStatus.IN_PROGRESS:
+      return 'In progress';
+    case TaskStatus.COMPLETED:
+      return 'Completed';
+    default:
+      throw new Error(
+        `taskStatusToText received an invalid taskStatus (status: ${status})`,
+      );
+  }
+};
+
+export const taskStatusToEnumName = (status: TaskStatus | number) => {
+  return TaskStatus[status];
+};
+
 // Accumulates results into provided map
 const ratingsSummaryByDimensionInto = (
   result: Map<TaskRatingDimension, RatingsSummary>,
@@ -157,7 +176,7 @@ export const taskSort = (type: SortingTypes | undefined): SortBy<Task> => {
     case SortingTypes.SORT_DESC:
       return sortKeyLocale('description');
     case SortingTypes.SORT_STATUS:
-      return sortKeyNumeric((t) => +(t.status === TaskStatus.COMPLETED));
+      return sortKeyNumeric('status');
     case SortingTypes.SORT_RATINGS:
       return sortKeyNumeric(calcTaskPriority);
     case SortingTypes.SORT_AVG_VALUE:

--- a/frontend/src/utils/TaskUtils.ts
+++ b/frontend/src/utils/TaskUtils.ts
@@ -9,6 +9,7 @@ import { UserInfo } from '../redux/user/types';
 import {
   RoleType,
   TaskRatingDimension,
+  TaskStatus,
 } from '../../../shared/types/customTypes';
 import { SortBy, sortKeyNumeric, sortKeyLocale } from './SortUtils';
 import { getType, isUserInfo } from './UserUtils';
@@ -127,7 +128,7 @@ export const ratedByCustomer = (
       rating.forCustomer === customer.id && rating.createdByUser === rep.id,
   );
 
-const completed = (task: Task) => task.completed;
+const completed = (task: Task) => task.status === TaskStatus.COMPLETED;
 
 export const taskFilter = (
   type: FilterTypes | undefined,
@@ -156,7 +157,7 @@ export const taskSort = (type: SortingTypes | undefined): SortBy<Task> => {
     case SortingTypes.SORT_DESC:
       return sortKeyLocale('description');
     case SortingTypes.SORT_STATUS:
-      return sortKeyNumeric((t) => +t.completed);
+      return sortKeyNumeric((t) => +(t.status === TaskStatus.COMPLETED));
     case SortingTypes.SORT_RATINGS:
       return sortKeyNumeric(calcTaskPriority);
     case SortingTypes.SORT_AVG_VALUE:

--- a/server/src/api/tasks/tasks.controller.ts
+++ b/server/src/api/tasks/tasks.controller.ts
@@ -92,7 +92,7 @@ export const patchTasks: RouteHandlerFnc = async (ctx) => {
   if (!ctx.state.user) {
     throw new Error('User is required');
   }
-  const { id, name, description, completed, ...others } = ctx.request.body;
+  const { id, name, description, status, ...others } = ctx.request.body;
   if (Object.keys(others).length) return void (ctx.status = 400);
 
   const res = await Task.transaction(async (trx) => {
@@ -110,7 +110,7 @@ export const patchTasks: RouteHandlerFnc = async (ctx) => {
     return void (ctx.body = await task.$query(trx).patchAndFetch({
       name: name,
       description: description,
-      completed: completed,
+      status: status,
     }));
   });
 

--- a/server/src/api/tasks/tasks.model.ts
+++ b/server/src/api/tasks/tasks.model.ts
@@ -33,8 +33,12 @@ export default class Task extends Model {
       description: { type: 'string', minLength: 1, maxLength: 1000 },
       roadmapId: { type: 'integer' },
       status: {
-        type: 'string',
-        enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'],
+        type: 'integer',
+        enum: [
+          TaskStatus.NOT_STARTED,
+          TaskStatus.IN_PROGRESS,
+          TaskStatus.COMPLETED,
+        ],
       },
       createdAt: { type: 'string', format: 'date-time' },
       createdByUser: { type: 'integer' },

--- a/server/src/api/tasks/tasks.model.ts
+++ b/server/src/api/tasks/tasks.model.ts
@@ -1,4 +1,5 @@
 import { QueryContext, AnyQueryBuilder } from 'objection';
+import { TaskStatus } from '../../../../shared/types/customTypes';
 import Model from '../BaseModel';
 import Roadmap from '../roadmaps/roadmaps.model';
 import TaskRating from '../taskratings/taskratings.model';
@@ -8,7 +9,7 @@ export default class Task extends Model {
   id!: number;
   name!: string;
   description!: string;
-  completed!: boolean;
+  status!: TaskStatus;
   createdAt!: string;
   importedFrom!: string | null;
   externalId!: string | null;
@@ -31,7 +32,10 @@ export default class Task extends Model {
       name: { type: 'string', minLength: 1, maxLength: 255 },
       description: { type: 'string', minLength: 1, maxLength: 1000 },
       roadmapId: { type: 'integer' },
-      completed: { type: 'boolean' },
+      status: {
+        type: 'string',
+        enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'],
+      },
       createdAt: { type: 'string', format: 'date-time' },
       createdByUser: { type: 'integer' },
       importedFrom: { type: ['string', 'null'], minLength: 1, maxLength: 255 },

--- a/server/src/migrations/20220310091901_integrationsRework.ts
+++ b/server/src/migrations/20220310091901_integrationsRework.ts
@@ -1,0 +1,64 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('integration', (table) => {
+    table
+      .integer('tokenId')
+      .references('id')
+      .inTable('integration')
+      .onDelete('SET NULL')
+      .index();
+  });
+
+  await knex.schema.createTable('trelloColumnMappings', (table) => {
+    table.increments('id').primary();
+    table
+      .integer('integrationId')
+      .references('id')
+      .inTable('integration')
+      .onDelete('CASCADE')
+      .index();
+
+    table.string('fromColumn', 75).notNullable();
+    table.enu('toStatus', ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'], {
+      useNative: true,
+      existingType: false,
+      enumName: 'task_status_type',
+    });
+    table.unique(['integrationId', 'fromColumn']);
+  });
+
+  await knex.schema.alterTable('tasks', (table) => {
+    table
+      .enu('status', [], {
+        useNative: true,
+        existingType: true,
+        enumName: 'task_status_type',
+      })
+      .defaultTo('NOT_STARTED');
+  });
+
+  await knex('tasks').where('completed', true).update({
+    status: 'COMPLETED',
+  });
+
+  await knex.schema.alterTable('tasks', (table) => {
+    table.dropColumn('completed');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('integration', (table) => {
+    table.dropColumn('tokenId');
+  });
+  await knex.schema.alterTable('tasks', (table) => {
+    table.boolean('completed').defaultTo(false);
+  });
+  await knex('tasks').where('status', 'COMPLETED').update({
+    completed: true,
+  });
+  await knex.schema.alterTable('tasks', (table) => {
+    table.dropColumn('status');
+  });
+  await knex.schema.dropTable('trelloColumnMappings');
+}

--- a/server/src/migrations/20220310091901_integrationsRework.ts
+++ b/server/src/migrations/20220310091901_integrationsRework.ts
@@ -8,6 +8,8 @@ export async function up(knex: Knex): Promise<void> {
       .inTable('integration')
       .onDelete('SET NULL')
       .index();
+
+    table.string('trelloTableId').nullable();
   });
 
   await knex.schema.createTable('trelloColumnMappings', (table) => {

--- a/server/src/migrations/20220310091901_integrationsRework.ts
+++ b/server/src/migrations/20220310091901_integrationsRework.ts
@@ -1,3 +1,4 @@
+import { TaskStatus } from './../../../shared/types/customTypes';
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
@@ -22,26 +23,16 @@ export async function up(knex: Knex): Promise<void> {
       .index();
 
     table.string('fromColumn', 75).notNullable();
-    table.enu('toStatus', ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'], {
-      useNative: true,
-      existingType: false,
-      enumName: 'task_status_type',
-    });
+    table.integer('toStatus').notNullable();
     table.unique(['integrationId', 'fromColumn']);
   });
 
   await knex.schema.alterTable('tasks', (table) => {
-    table
-      .enu('status', [], {
-        useNative: true,
-        existingType: true,
-        enumName: 'task_status_type',
-      })
-      .defaultTo('NOT_STARTED');
+    table.integer('status').notNullable().defaultTo(0);
   });
 
   await knex('tasks').where('completed', true).update({
-    status: 'COMPLETED',
+    status: TaskStatus.COMPLETED,
   });
 
   await knex.schema.alterTable('tasks', (table) => {
@@ -56,7 +47,7 @@ export async function down(knex: Knex): Promise<void> {
   await knex.schema.alterTable('tasks', (table) => {
     table.boolean('completed').defaultTo(false);
   });
-  await knex('tasks').where('status', 'COMPLETED').update({
+  await knex('tasks').where('status', TaskStatus.COMPLETED).update({
     completed: true,
   });
   await knex.schema.alterTable('tasks', (table) => {

--- a/server/src/seeds/testdata.ts
+++ b/server/src/seeds/testdata.ts
@@ -6,7 +6,10 @@ import Task from '../api/tasks/tasks.model';
 import { Role } from '../api/roles/roles.model';
 import Version from '../api/versions/versions.model';
 import { TaskRelation } from '../api/taskrelation/taskrelation.model';
-import { TaskRelationType } from '../../../shared/types/customTypes';
+import {
+  TaskRelationType,
+  TaskStatus,
+} from '../../../shared/types/customTypes';
 import {
   RoleType,
   TaskRatingDimension,
@@ -208,7 +211,7 @@ const createTestTasks = async () => {
       ratings: defaultRatings.map(({ createdBy, createdFor, dimension }) =>
         randomTaskratingValue(createdBy, createdFor, dimension),
       ),
-      status: 'COMPLETED',
+      status: TaskStatus.COMPLETED,
     },
     {
       name: 'Test task 3',
@@ -225,7 +228,7 @@ const createTestTasks = async () => {
       ratings: defaultRatings.map(({ createdBy, createdFor, dimension }) =>
         randomTaskratingValue(createdBy, createdFor, dimension),
       ),
-      status: 'COMPLETED',
+      status: TaskStatus.COMPLETED,
     },
     {
       name: 'Test task 5',
@@ -282,7 +285,7 @@ const createTestTasks = async () => {
       },
     )
     .upsertGraph(
-      { tasks: tasks as any, id: roadmaps[1].id },
+      { tasks, id: roadmaps[1].id },
       {
         relate: true,
         noInsert: ['tasks.ratings.createdBy', 'tasks.ratings.createdFor'],

--- a/server/src/seeds/testdata.ts
+++ b/server/src/seeds/testdata.ts
@@ -208,7 +208,7 @@ const createTestTasks = async () => {
       ratings: defaultRatings.map(({ createdBy, createdFor, dimension }) =>
         randomTaskratingValue(createdBy, createdFor, dimension),
       ),
-      completed: true,
+      status: 'COMPLETED',
     },
     {
       name: 'Test task 3',
@@ -225,7 +225,7 @@ const createTestTasks = async () => {
       ratings: defaultRatings.map(({ createdBy, createdFor, dimension }) =>
         randomTaskratingValue(createdBy, createdFor, dimension),
       ),
-      completed: true,
+      status: 'COMPLETED',
     },
     {
       name: 'Test task 5',
@@ -272,7 +272,7 @@ const createTestTasks = async () => {
   const roadmaps = await Roadmap.query().select('id');
   await Roadmap.query()
     .upsertGraph(
-      { tasks: tasks.splice(0, 6), id: roadmaps[0].id },
+      { tasks: (tasks as any).splice(0, 6), id: roadmaps[0].id },
       {
         relate: true,
         noInsert: ['tasks.ratings.createdBy', 'tasks.ratings.createdFor'],
@@ -282,7 +282,7 @@ const createTestTasks = async () => {
       },
     )
     .upsertGraph(
-      { tasks, id: roadmaps[1].id },
+      { tasks: tasks as any, id: roadmaps[1].id },
       {
         relate: true,
         noInsert: ['tasks.ratings.createdBy', 'tasks.ratings.createdFor'],

--- a/server/src/utils/socketIoUtils.ts
+++ b/server/src/utils/socketIoUtils.ts
@@ -89,9 +89,6 @@ export const emitRoadmapEvent = async <T extends ClientEvents>(
     eventParams: parameters,
   } = { ...emitRoadmapEventParams };
 
-  console.log('Emitting roadmap socket event:');
-  console.log(JSON.stringify(emitRoadmapEventParams, undefined, 2));
-
   const roomName = `roadmap-${roadmapId}`;
   const roadmapSockets = await io.in(roomName).fetchSockets<ISocketData>();
   const socketUserIds = roadmapSockets.map((s) => s.data.user.id);
@@ -99,11 +96,6 @@ export const emitRoadmapEvent = async <T extends ClientEvents>(
     .findByIds(socketUserIds)
     .withGraphJoined('roles')
     .where('roles.roadmapId', roadmapId);
-
-  console.log('socketUsers:');
-  socketUsers.forEach((u) => {
-    console.log(u.email);
-  });
 
   const usersWithPermission = requirePermission
     ? socketUsers.filter((user) =>
@@ -116,6 +108,5 @@ export const emitRoadmapEvent = async <T extends ClientEvents>(
 
     // Sockets are added to a room with their associated user id when they connect to allow sending like this
     io.to(`${user.id}`).emit(event, ...parameters);
-    console.log(`Emitting to: ${user.email}`);
   }
 };

--- a/server/tests/tasks.test.ts
+++ b/server/tests/tasks.test.ts
@@ -24,7 +24,7 @@ describe('Test /roadmaps/:roadmapId/tasks/ api', function () {
       expect(res.body[0]).to.have.property('id');
       expect(res.body[0]).to.have.property('name');
       expect(res.body[0]).to.have.property('description');
-      expect(res.body[0]).to.have.property('completed');
+      expect(res.body[0]).to.have.property('status');
       expect(res.body[0]).to.have.property('createdAt');
       expect(res.body[0]).to.have.property('roadmapId');
       expect(res.body[0]).to.have.property('createdByUser');

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -3,6 +3,12 @@ export enum TaskRelationType {
   Synergy,
 }
 
+export enum TaskStatus {
+  NOT_STARTED = "NOT_STARTED",
+  IN_PROGRESS = "IN_PROGRESS",
+  COMPLETED = "COMPLETED",
+}
+
 export enum TaskRatingDimension {
   BusinessValue = 0,
   Complexity = 1,

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -4,9 +4,9 @@ export enum TaskRelationType {
 }
 
 export enum TaskStatus {
-  NOT_STARTED = "NOT_STARTED",
-  IN_PROGRESS = "IN_PROGRESS",
-  COMPLETED = "COMPLETED",
+  NOT_STARTED = 0,
+  IN_PROGRESS = 1,
+  COMPLETED = 2,
 }
 
 export enum TaskRatingDimension {


### PR DESCRIPTION
- Add task status enum to replace "completed" boolean.
- Add trellomappings table to store mappings for an integration from trello column names to task statuses
- Add tokenId column to integrations to reference a token that is to be used during imports using said integration
- Add nullable trelloTableId column to integrations to reference a table name that is to be used during imports from trello