### PR TITLE
Add drag-n-drop instructions to MilestonesEditor

### DIFF
--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -72,6 +72,7 @@ export const english = {
     'Rate customer': 'Rate customer',
     milestones: 'milestones',
     Milestones: 'Milestones',
+    'Milestone task instructions': 'Drag & drop tasks here',
     'Add milestone': 'Add milestone',
     'Milestone name': 'Milestone name',
     'Delete milestone': 'Delete milestone',

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -87,3 +87,19 @@
   width: 34px;
   height: 34px;
 }
+
+.instructions {
+  @extend .typography-pre-title;
+  @extend .layout-column;
+  align-items: center;
+  justify-content: center;
+  min-height: 84px;
+  color: $COLOR_BLACK40;
+  margin: 16px;
+  margin-top: 0;
+
+  .text {
+    padding: 15px;
+    padding-bottom: 0;
+  }
+}

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -270,13 +270,32 @@ export const MilestonesEditor = () => {
                     >
                       {version.name}
                     </div>
-
-                    <SortableTaskList
-                      listId={`${version.id}`}
-                      tasks={versionLists[version.id] || []}
-                      disableDragging={disableDrag}
-                      className={classes(css.milestone)}
-                    />
+                    {versionLists[version.id]?.length === 0 ? (
+                      <Droppable droppableId={`${version.id}`} type="TASKS">
+                        {(provided, snapshot) => (
+                          <div
+                            className={classes(css.instructions, {
+                              [css.highlight]: snapshot.isDraggingOver,
+                              'loading-cursor': disableDrag,
+                            })}
+                            ref={provided.innerRef}
+                            {...provided.droppableProps}
+                          >
+                            <div className={classes(css.text)}>
+                              <Trans i18nKey="Milestone task instructions" />
+                            </div>
+                            {provided.placeholder}
+                          </div>
+                        )}
+                      </Droppable>
+                    ) : (
+                      <SortableTaskList
+                        listId={`${version.id}`}
+                        tasks={versionLists[version.id] || []}
+                        disableDragging={disableDrag}
+                        className={classes(css.milestone)}
+                      />
+                    )}
                     <div className={classes(css.ratingsSummaryWrapper)}>
                       <MilestoneRatingsSummary
                         tasks={versionLists[version.id] || []}


### PR DESCRIPTION
If no milestones have tasks, display a drag-n-drop info message in all milestones.

The branch name is a bit outdated, it was decided that all milestones should have the instruction in this case.