### PR TITLE
Don't perform empty query

### DIFF
--- a/server/src/utils/typeValidation.ts
+++ b/server/src/utils/typeValidation.ts
@@ -1,5 +1,9 @@
 type typeValidator<T> = (value: any) => value is T;
 
+export const isOptional = <T>(validateItem: typeValidator<T>) => (
+  value: unknown,
+): value is T | undefined => value === undefined || validateItem(value);
+
 export const isTypedArray = <T>(validateItem: typeValidator<T>) => (
   value: unknown,
 ): value is T[] => {


### PR DESCRIPTION
When an empty representatives array was provided, the query would fail.

Also added a bit more type validation.