### PR TITLE
Fix task overview route and 404 redirect

### DIFF
--- a/frontend/src/components/TaskTableRated.tsx
+++ b/frontend/src/components/TaskTableRated.tsx
@@ -50,7 +50,7 @@ const TableRatedTaskRow: TableRow<Task> = ({ item: task, style }) => {
   return (
     <Link
       className={classes(css.navBarLink, css.hoverRow)}
-      to={`${paths.roadmapHome}/${task.roadmapId}${paths.roadmapRelative.tasks}/task/${task.id}`}
+      to={`${paths.roadmapHome}/${task.roadmapId}${paths.roadmapRelative.tasks}/${task.id}`}
     >
       <div
         style={style}

--- a/frontend/src/components/TaskTableUnrated.tsx
+++ b/frontend/src/components/TaskTableUnrated.tsx
@@ -59,7 +59,7 @@ const TableUnratedTaskRow: TableRow<Task> = ({ item: task, style }) => {
   return (
     <Link
       className={classes(css.navBarLink, css.hoverRow)}
-      to={`${paths.roadmapHome}/${task.roadmapId}${paths.roadmapRelative.tasks}/task/${task.id}`}
+      to={`${paths.roadmapHome}/${task.roadmapId}${paths.roadmapRelative.tasks}/${task.id}`}
     >
       <div style={style} className={classes(css.virtualizedTableRow)}>
         <div className={classes(css.taskTitle)}>{name}</div>

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -31,6 +31,7 @@ import css from './TaskOverviewPage.module.scss';
 import { MissingRatings } from '../components/MissingRatings';
 import { TaskModalButtons } from '../components/TaskModalButtons';
 import { apiV2 } from '../api/api';
+import { LoadingSpinner } from '../components/LoadingSpinner';
 
 const classes = classNames.bind(css);
 
@@ -191,8 +192,11 @@ const TaskOverview: FC<{
 export const TaskOverviewPage = () => {
   const { taskId } = useParams<{ taskId: string | undefined }>();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
+  const { data: tasks, isFetching } = apiV2.useGetTasksQuery(
+    roadmapId ?? skipToken,
+  );
   const taskIdx = tasks?.findIndex(({ id }) => Number(taskId) === id);
+  if (isFetching) return <LoadingSpinner />;
   if (!tasks || taskIdx === undefined || taskIdx < 0)
     return <Redirect to={paths.notFound} />;
   return <TaskOverview tasks={tasks} task={tasks[taskIdx]} taskIdx={taskIdx} />;

--- a/frontend/src/routers/paths.ts
+++ b/frontend/src/routers/paths.ts
@@ -36,6 +36,6 @@ export const paths = {
   tasksRelative: {
     tasklist: '/tasklist',
     taskmap: '/taskmap',
-    taskOverview: '/task/:taskId([0-9]+)',
+    taskOverview: '/:taskId([0-9]+)',
   },
 };


### PR DESCRIPTION
Pressing F5 on task overview page previously redirected to a 404 because the page did not wait for loading first.

Also changed path to /tasks/taskid instead of /tasks/task/taskid
