### PR TITLE
Fix multi-rating bug

### DIFF
--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -178,7 +178,7 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
     idx: number,
     forCustomer?: number,
   ) => (rating: { value: number; comment: string | undefined }) => {
-    const copy = [...ratings];
+    const copy = [...businessValueRatings];
     const original = copy[idx];
     copy[idx] = { ...original, ...rating, forCustomer, changed: true };
     setBusinessValueRatings(copy);


### PR DESCRIPTION
When user had given multiple ratings in the modal, only the latest would get appended to the request.

This was due to a wrong variable used in onBusinessRatingChange event handler. Now all changed ratings are appended to the request.