### PR TITLE
Fix milestone styles

### DIFF
--- a/frontend/src/components/MilestoneRatingsSummary.module.scss
+++ b/frontend/src/components/MilestoneRatingsSummary.module.scss
@@ -12,4 +12,7 @@
   display: flex;
   flex-grow: 1;
   justify-content: flex-end;
+  align-items: flex-end;
+  position: relative;
+  top: -3px;
 }

--- a/frontend/src/components/SortableTaskList.module.scss
+++ b/frontend/src/components/SortableTaskList.module.scss
@@ -7,7 +7,7 @@
 
 .sortableList {
   @extend .layout-column;
-  flex-grow: 1;
+  height: 100%;
   overflow-y: visible;
   background-color: transparent;
   width: 100%;

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -42,13 +42,6 @@
   padding: 13px;
 }
 
-.sortableListWrapper.milestone {
-  height: 100%;
-  padding: 0px;
-  padding-top: 7px;
-  padding-bottom: 1px;
-}
-
 .ratingsSummaryWrapper {
   border-top: 1px solid $COLOR_BLACK10;
   padding: 15px;

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -43,13 +43,13 @@
 }
 
 .sortableListWrapper.milestone {
+  height: 100%;
   padding: 0px;
   padding-top: 7px;
   padding-bottom: 1px;
 }
 
 .ratingsSummaryWrapper {
-  @extend .sortableListWrapper;
   border-top: 1px solid $COLOR_BLACK10;
   padding: 15px;
   padding-right: 11px;
@@ -60,7 +60,8 @@
   @extend .shadow-roadmapblock;
   display: flex;
   flex-direction: column;
-  min-height: 150px;
+  height: 100%;
+  min-height: 330px;
   width: 200px;
   border-radius: 10px;
   background-color: white;
@@ -93,7 +94,7 @@
   @extend .layout-column;
   align-items: center;
   justify-content: center;
-  min-height: 84px;
+  height: 100%;
   color: $COLOR_BLACK40;
   margin: 16px;
   margin-top: 0;

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -293,7 +293,6 @@ export const MilestonesEditor = () => {
                         listId={`${version.id}`}
                         tasks={versionLists[version.id] || []}
                         disableDragging={disableDrag}
-                        className={classes(css.milestone)}
                       />
                     )}
                     <div className={classes(css.ratingsSummaryWrapper)}>


### PR DESCRIPTION
Milestones now fill the (vertical) space available for them.
This fixes the problem of too short milestone task lists. It was caused by AutoSizer, which does not stretch content