### PR TITLE
Add confirmation to change password

### DIFF
--- a/frontend/src/components/UserInfoCard.module.scss
+++ b/frontend/src/components/UserInfoCard.module.scss
@@ -35,3 +35,9 @@
   @extend .layout-row;
   min-width: 400px;
 }
+
+.passwordButton {
+  @extend .button-small-filled;
+  justify-content: center;
+  display: flex;
+}

--- a/frontend/src/components/UserInfoCard.tsx
+++ b/frontend/src/components/UserInfoCard.tsx
@@ -93,12 +93,12 @@ export const UserInfoCard = ({ userInfo }: { userInfo: UserInfo }) => {
       }),
     );
   };
-  const passwordOnOk = async (newValue: string) => {
+  const openChangePasswordModal = () => {
     dispatch(
       modalsActions.showModal({
-        modalType: ModalTypes.CONFIRM_PASSWORD_MODAL,
+        modalType: ModalTypes.CHANGE_PASSWORD_MODAL,
         modalProps: {
-          actionData: { id: userInfo.id, password: newValue },
+          id: userInfo.id,
         },
       }),
     );
@@ -150,15 +150,13 @@ export const UserInfoCard = ({ userInfo }: { userInfo: UserInfo }) => {
           </div>
         </div>
         <div>
-          <p className={classes(css.subtitle)}>
-            <Trans i18nKey="Password" />
-          </p>
-          <EditableTextWithButtons
-            onOk={passwordOnOk}
-            value="********"
-            fieldId="password"
-            format=""
-          />
+          <button
+            className={classes(css.passwordButton)}
+            type="button"
+            onClick={() => openChangePasswordModal()}
+          >
+            <Trans i18nKey="Change password" />
+          </button>
         </div>
       </div>
       <ProjectTable items={userInfo.roles} />

--- a/frontend/src/components/forms/FormField.module.scss
+++ b/frontend/src/components/forms/FormField.module.scss
@@ -3,6 +3,17 @@
 .fieldContainer {
   @extend .layout-column;
   gap: 0.8rem;
+
+  label {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+}
+
+.tooltipIcon {
+  width: 14px;
+  height: 14px;
 }
 
 .fieldError {

--- a/frontend/src/components/forms/FormField.tsx
+++ b/frontend/src/components/forms/FormField.tsx
@@ -8,7 +8,9 @@ import {
 } from 'react';
 import { TextareaAutosize } from '@mui/material';
 import classNames from 'classnames';
+import InfoIcon from '@mui/icons-material/InfoOutlined';
 import css from './FormField.module.scss';
+import { InfoTooltip } from '../InfoTooltip';
 
 const classes = classNames.bind(css);
 
@@ -20,6 +22,7 @@ interface FieldType extends HTMLElement {
 
 export interface FieldProps<T extends FieldType> extends HTMLProps<T> {
   label?: string;
+  labelHint?: string;
   error?: {
     message: string;
     setMessage: (_: string) => void;
@@ -57,6 +60,7 @@ function field<T extends FieldType>(
   return ({
     error = errorState(useState('')),
     label,
+    labelHint,
     innerRef,
     id,
     ...props
@@ -71,7 +75,16 @@ function field<T extends FieldType>(
     }, [ref, error.message, innerRef]);
     return (
       <div className={classes(css.fieldContainer)}>
-        {label && <label htmlFor={id}>{label}</label>}
+        {label && (
+          <label htmlFor={id}>
+            {label}
+            {labelHint && (
+              <InfoTooltip title={labelHint}>
+                <InfoIcon className={classes(css.tooltipIcon)} />
+              </InfoTooltip>
+            )}
+          </label>
+        )}
         <Tag
           {...props}
           ref={ref}

--- a/frontend/src/components/modals/ChangePasswordModal.module.scss
+++ b/frontend/src/components/modals/ChangePasswordModal.module.scss
@@ -1,0 +1,5 @@
+@import '../../shared.scss';
+
+.changePasswordForm {
+  max-width: 500px;
+}

--- a/frontend/src/components/modals/ModalRoot.tsx
+++ b/frontend/src/components/modals/ModalRoot.tsx
@@ -30,6 +30,7 @@ import { JoinProjectModal } from './JoinProjectModal';
 import { JoinLinkInvalidModal } from './JoinLinkInvalidModal';
 import { JoinLinkNoAccessModal } from './JoinLinkNoAccessModal';
 import { ConfirmPasswordModal } from './ConfirmPasswordModal';
+import { ChangePasswordModal } from './ChangePasswordModal';
 import { InfoModal } from './InfoModal';
 import { LeaveRoadmapModal } from './LeaveRoadmapModal';
 
@@ -57,6 +58,7 @@ const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.JOIN_LINK_INVALID_MODAL]: JoinLinkInvalidModal,
   [ModalTypes.JOIN_LINK_NO_ACCESS_MODAL]: JoinLinkNoAccessModal,
   [ModalTypes.CONFIRM_PASSWORD_MODAL]: ConfirmPasswordModal,
+  [ModalTypes.CHANGE_PASSWORD_MODAL]: ChangePasswordModal,
   [ModalTypes.INFO_MODAL]: InfoModal,
   [ModalTypes.LEAVE_ROADMAP_MODAL]: LeaveRoadmapModal,
 } as const;

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -34,6 +34,7 @@ export enum ModalTypes {
   JOIN_LINK_INVALID_MODAL = 'JOIN_LINK_INVALID_MODAL',
   JOIN_LINK_NO_ACCESS_MODAL = 'JOIN_LINK_NO_ACCESS_MODAL',
   CONFIRM_PASSWORD_MODAL = 'CONFIRM_PASSWORD_MODAL',
+  CHANGE_PASSWORD_MODAL = 'CHANGE_PASSWORD_MODAL',
   INFO_MODAL = 'INFO_MODAL',
   LEAVE_ROADMAP_MODAL = 'LEAVE_ROADMAP_MODAL',
 }
@@ -99,6 +100,7 @@ type OwnProps = {
         actionData: Omit<UserDeleteRequest, 'currentPassword'>;
         deleteUser: true;
       };
+  [ModalTypes.CHANGE_PASSWORD_MODAL]: { id: number };
   [ModalTypes.INFO_MODAL]: { header: string; content: InfoModalContent };
   [ModalTypes.LEAVE_ROADMAP_MODAL]: {
     roadmapId: number;

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -315,6 +315,8 @@ export const english = {
       'Client weights affect the scaling of milestone`s total values in the roadmap graph. Weight of 0% will ignore the ratings of the client in question.',
     'Compare milestone durations with different estimates.':
       'Compare milestone durations with different estimates.',
+    'Bad request - password':
+      'Bad request error - is current password correct?',
     Realization: 'Realization',
     'system calculated average values over time':
       'system calculated average values over time.',
@@ -349,6 +351,11 @@ export const english = {
     'Error message': 'Error: {{error}}.',
     'Email service error': 'Email service error',
     'This email doesn’t exist': 'This email doesn’t exist',
+    'Change password': 'Change password',
+    'Current password': 'Current password',
+    'New password': 'New password',
+    'Confirm new password': 'Confirm new password',
+    'Password requirements': 'Must contain at least 8 characters',
     You: 'You',
     'deleted account': 'deleted account',
     'Last modified by': 'Last modified by',

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -139,7 +139,7 @@ export const MainRouter = () => {
 
     dispatch(
       modalsActions.showModal({
-        modalType: queryModal as ModalTypes,
+        modalType: queryModal as any,
         modalProps: queryProps as any,
       }),
     );


### PR DESCRIPTION
So I made the change password modal that is in style with whats on Figma (except for those toggles that let you see passwords in cleartext. Should i make a new task in Trello to add those in this modal and maybe to ResetPassword modal?)

With this change, that EditableTextWithButtons don't really make sense to me. 
![image](https://user-images.githubusercontent.com/101560117/159740841-c4540492-0088-40c2-a1f7-05e4e087e63d.png)
Should this just be some kind of a button that opens the modal? I temporarily used linkButton for the functionality.