### PR TITLE
Fix relation overview edit

### DIFF
--- a/frontend/src/components/TaskRelationTable.module.scss
+++ b/frontend/src/components/TaskRelationTable.module.scss
@@ -2,8 +2,8 @@
 
 .listContainer {
   flex-grow: 1;
-  min-width: 370px;
-  max-width: 400px;
+  min-width: 387px;
+  max-width: 420px;
   margin-bottom: 5px;
 }
 

--- a/frontend/src/components/TaskRelationTable.tsx
+++ b/frontend/src/components/TaskRelationTable.tsx
@@ -12,7 +12,10 @@ import CheckIcon from '@mui/icons-material/Check';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 import SearchIcon from '@mui/icons-material/Search';
 import { Task, TaskRelation } from '../redux/roadmaps/types';
-import { TaskRelationType } from '../../../shared/types/customTypes';
+import {
+  TaskRelationType,
+  TaskStatus,
+} from '../../../shared/types/customTypes';
 import { paths } from '../routers/paths';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import {
@@ -25,7 +28,6 @@ import { TaskRatingsText } from './TaskRatingsText';
 import { CloseButton } from './forms/SvgButton';
 import css from './TaskRelationTable.module.scss';
 import { apiV2 } from '../api/api';
-import { TaskStatus } from '../../../shared/types/customTypes';
 
 const classes = classNames.bind(css);
 
@@ -37,7 +39,6 @@ interface RelationTableDef {
 type RelationTableProps = {
   task: Task;
   height?: number;
-  editMode: boolean;
 };
 
 const RelationRow: FC<{
@@ -71,7 +72,7 @@ const DropdownIndicator = () => <SearchIcon />;
 const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
   type,
   buildRelation,
-}) => ({ task, editMode, height = 500 }) => {
+}) => ({ task, height = 500 }) => {
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: relations } = apiV2.useGetTaskRelationsQuery(
     roadmapId ?? skipToken,
@@ -136,34 +137,30 @@ const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
           <Trans i18nKey={TaskRelationTableType[type]} />
         </h3>
       </div>
-      {editMode && (
-        <>
-          <Select
-            components={{ DropdownIndicator }}
-            name="relation"
-            id="new-relation"
-            classNamePrefix="react-select-relation"
-            styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
-            placeholder="Add relation"
-            isDisabled={availableConnections.length === 0}
-            value={null}
-            escapeClearsValue
-            onChange={(selected) => {
-              if (selected && roadmapId !== undefined) {
-                addTaskRelation({
-                  roadmapId,
-                  relation: buildRelation(task.id, selected.value),
-                });
-              }
-            }}
-            options={availableConnections.map(({ id, name }) => ({
-              value: id,
-              label: name,
-            }))}
-          />
-          <br />
-        </>
-      )}
+      <Select
+        components={{ DropdownIndicator }}
+        name="relation"
+        id="new-relation"
+        classNamePrefix="react-select-relation"
+        styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
+        placeholder="Add relation"
+        isDisabled={availableConnections.length === 0}
+        value={null}
+        escapeClearsValue
+        onChange={(selected) => {
+          if (selected && roadmapId !== undefined) {
+            addTaskRelation({
+              roadmapId,
+              relation: buildRelation(task.id, selected.value),
+            });
+          }
+        }}
+        options={availableConnections.map(({ id, name }) => ({
+          value: id,
+          label: name,
+        }))}
+      />
+      <br />
       {!tasks.length ? (
         <div className={classes(css.noRelations)}>
           <Trans i18nKey="No relations" />
@@ -174,13 +171,11 @@ const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
           itemSize={(idx) => rowHeights[idx] ?? 0}
           itemCount={tasks.length}
           height={Math.min(height, listHeight)}
-          width={editMode ? '105%' : '100%'}
+          width="105%"
         >
           {({ index, style }) => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { height: _, width, ...rest } = style;
             const { id } = tasks[index];
-            return editMode ? (
+            return (
               <div style={{ ...style, display: 'flex', alignItems: 'center' }}>
                 <RelationRow task={tasks[index]} />
                 <CloseButton
@@ -196,8 +191,6 @@ const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
                   }}
                 />
               </div>
-            ) : (
-              <RelationRow style={{ ...rest }} task={tasks[index]} />
             );
           }}
         </VariableSizeList>

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -36,8 +36,6 @@ export const english = {
     'Not started': 'Not started',
     'Not completed': 'Not completed',
     'Rate task': 'Rate task',
-    Edit: 'Edit',
-    'Close edit': 'Close edit',
     'Edit ratings': 'Edit ratings',
     'Add a comment': 'Add a comment...',
     Roadmap: 'Roadmap',

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 // useTranslation is a hook and thus can't be used in a function
@@ -30,7 +30,6 @@ import colors from '../colors.module.scss';
 import css from './TaskOverviewPage.module.scss';
 import { MissingRatings } from '../components/MissingRatings';
 import { TaskModalButtons } from '../components/TaskModalButtons';
-import { CloseButton, EditButton } from '../components/forms/SvgButton';
 import { apiV2 } from '../api/api';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 
@@ -114,7 +113,6 @@ const TaskOverview: FC<{
     (hasPermission(role, Permission.TaskEdit) && task.createdByUser === userId);
   const tasksPage = `${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.tasks}`;
   const [patchTaskTrigger] = apiV2.usePatchTaskMutation();
-  const [editMode, setEditMode] = useState(false);
 
   const siblingTasks = [
     {
@@ -156,31 +154,11 @@ const TaskOverview: FC<{
       <div className={classes(css.section)}>
         <div className={classes(css.header)}>
           <h2>{t('Relations')}</h2>
-          <div>
-            <button
-              type="button"
-              className={classes(css.actionButton)}
-              tabIndex={0}
-              onClick={() => setEditMode((prev) => !prev)}
-            >
-              {editMode ? (
-                <>
-                  <CloseButton onClick={() => {}} />
-                  {t('Close edit')}
-                </>
-              ) : (
-                <>
-                  <EditButton fontSize="small" onClick={() => {}} />
-                  {t('Edit')}
-                </>
-              )}
-            </button>
-          </div>
         </div>
         <div className={classes(css.relations)}>
-          <RelationTableRequires task={task} editMode={editMode} />
-          <RelationTableContributes task={task} editMode={editMode} />
-          <RelationTablePrecedes task={task} editMode={editMode} />
+          <RelationTableRequires task={task} />
+          <RelationTableContributes task={task} />
+          <RelationTablePrecedes task={task} />
         </div>
       </div>
 

--- a/server/src/api/taskrelation/taskrelation.routes.ts
+++ b/server/src/api/taskrelation/taskrelation.routes.ts
@@ -17,17 +17,17 @@ taskrelationRouter.get(
 );
 taskrelationRouter.post(
   '/relations',
-  requirePermission(Permission.TaskRead | Permission.RoadmapEdit),
+  requirePermission(Permission.EditRelations),
   addRelation,
 );
 taskrelationRouter.post(
   '/relations/synergies',
-  requirePermission(Permission.TaskRead | Permission.RoadmapEdit),
+  requirePermission(Permission.EditRelations),
   addSynergies,
 );
 taskrelationRouter.delete(
   '/relations',
-  requirePermission(Permission.TaskRead | Permission.RoadmapEdit),
+  requirePermission(Permission.EditRelations),
   deleteRelation,
 );
 

--- a/server/src/migrations/20220328122849_BusinessAndDeveloperUsersEditRelations.ts
+++ b/server/src/migrations/20220328122849_BusinessAndDeveloperUsersEditRelations.ts
@@ -1,0 +1,64 @@
+import { Permission } from '../../../shared/types/customTypes';
+import { Knex } from 'knex';
+import { Role } from '../api/roles/roles.model';
+import { Model } from 'objection';
+
+const oldBusinessRole =
+  Permission.TaskRead |
+  Permission.TaskCreate |
+  Permission.TaskEdit |
+  Permission.TaskDelete |
+  Permission.TaskRate |
+  Permission.TaskRatingEdit |
+  Permission.TaskValueRate |
+  Permission.CustomerRepresent |
+  Permission.RoadmapReadUsers;
+
+const newBusinessRole = oldBusinessRole | Permission.EditRelations;
+
+const oldDeveloperRole =
+  Permission.TaskRead |
+  Permission.TaskRate |
+  Permission.TaskCreate |
+  Permission.TaskRatingEdit |
+  Permission.TaskComplexityRate |
+  Permission.VersionRead |
+  Permission.RoadmapReadUsers;
+
+const newDeveloperRole = oldDeveloperRole | Permission.EditRelations;
+
+export async function up(knex: Knex): Promise<void> {
+  Model.knex(knex);
+  await Role.query()
+    .where({
+      type: oldBusinessRole,
+    })
+    .update({
+      type: newBusinessRole,
+    });
+  await Role.query()
+    .where({
+      type: oldDeveloperRole,
+    })
+    .update({
+      type: newDeveloperRole,
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  Model.knex(knex);
+  await Role.query()
+    .where({
+      type: newBusinessRole,
+    })
+    .update({
+      type: oldBusinessRole,
+    });
+  await Role.query()
+    .where({
+      type: newDeveloperRole,
+    })
+    .update({
+      type: oldDeveloperRole,
+    });
+}

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -48,6 +48,8 @@ export enum Permission {
   IntegrationConfigurationEdit = 1 << 21,
 
   RoadmapInvite = 1 << 22,
+
+  EditRelations = 1 << 23,
 }
 
 export enum RoleType {
@@ -58,7 +60,8 @@ export enum RoleType {
     Permission.TaskRatingEdit |
     Permission.TaskComplexityRate |
     Permission.VersionRead |
-    Permission.RoadmapReadUsers,
+    Permission.RoadmapReadUsers |
+    Permission.EditRelations,
   Business = Permission.TaskRead |
     Permission.TaskCreate |
     Permission.TaskEdit |
@@ -67,5 +70,6 @@ export enum RoleType {
     Permission.TaskRatingEdit |
     Permission.TaskValueRate |
     Permission.CustomerRepresent |
-    Permission.RoadmapReadUsers,
+    Permission.RoadmapReadUsers |
+    Permission.EditRelations,
 }


### PR DESCRIPTION
https://trello.com/c/QG9uK4c6/576-taskin-relaatioiden-editointi-n%C3%A4kyy-kaikille-k%C3%A4ytt%C3%A4jile-overviewss%C3%A4

- Task relation edit mode is always kept open
- Taskrelation routes are made accessible to all users
  - EditRelations permission is added to Developer and Business RoleTypes.
 It is used in taskrelation-routes in place of (Permission.TaskRead | Permission.RoadmapEdit)