### PR TITLE
Fix integration token foreign key

### DIFF
--- a/server/src/api/tokens/tokens.model.ts
+++ b/server/src/api/tokens/tokens.model.ts
@@ -8,6 +8,8 @@ export default class Token extends Model {
   type!: string;
   value!: string;
 
+  forIntegration!: number | null;
+
   belongsToUser!: User;
 
   static tableName = 'tokens';

--- a/server/src/migrations/20220328112527_fixIntegrationTokenForeignKey.ts
+++ b/server/src/migrations/20220328112527_fixIntegrationTokenForeignKey.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('integration', (table) => {
+    table.dropColumn('tokenId');
+  });
+  await knex.schema.alterTable('tokens', (table) => {
+    table
+      .integer('forIntegration')
+      .references('id')
+      .inTable('integration')
+      .onDelete('CASCADE')
+      .index();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('tokens', (table) => {
+    table.dropColumn('forIntegration');
+  });
+  await knex.schema.alterTable('integration', (table) => {
+    table
+      .integer('tokenId')
+      .references('id')
+      .inTable('integration')
+      .onDelete('SET NULL')
+      .index();
+  });
+}

--- a/server/src/utils/errorhandler.ts
+++ b/server/src/utils/errorhandler.ts
@@ -67,7 +67,7 @@ export const errorHandler = async (ctx: Context, next: () => Promise<any>) => {
       ctx.status = 403;
       ctx.body = err.message;
     } else if (err instanceof InvalidTokenError) {
-      ctx.status = 401;
+      ctx.status = 403;
       ctx.body = {
         error: 'InvalidTokenError',
         message: err.message,


### PR DESCRIPTION
I totally missed this one when reviewing the migration.

The token now has nullable foreign key to integration, since each oauth needs two entries in token table.

Also fixed the status code for invalid integration tokens, which was unpleasantly broken after we added the middleware for 401 (unauthorised) responses.