### PR TITLE
Submit multiline EditableText on shift + enter

### DIFF
--- a/frontend/src/components/EditableText.tsx
+++ b/frontend/src/components/EditableText.tsx
@@ -19,6 +19,7 @@ interface WithButtonsProps {
   value: string;
   fieldId: string;
   format: string | undefined;
+  multiline?: true;
 }
 
 const withButtons = (Component: typeof EditableText) => ({
@@ -26,6 +27,7 @@ const withButtons = (Component: typeof EditableText) => ({
   value,
   fieldId,
   format,
+  multiline,
 }: WithButtonsProps) => {
   const [editOpen, setEditOpen] = useState(false);
   const [editText, setEditText] = useState('');
@@ -57,6 +59,7 @@ const withButtons = (Component: typeof EditableText) => ({
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     switch (event.key) {
       case 'Enter':
+        if (multiline && !event.shiftKey) return;
         event.preventDefault();
         handleConfirm();
         break;

--- a/frontend/src/components/Overview.tsx
+++ b/frontend/src/components/Overview.tsx
@@ -76,6 +76,7 @@ export const OverviewContent: FC<OverviewContentProps> = ({
                   value={value}
                   fieldId={keyName}
                   format={format}
+                  multiline
                 />
               ) : (
                 <div className={classes(css.value)}>{value}</div>


### PR DESCRIPTION
Before, user could not add newlines to the EditableText box.
Now newlines can be added with the enter-key and the field can be submitted with shift + enter.
- Added multiline prop, because EditableText is used in email field (user info page) where multiple lines are not desired.

I am not actually sure if it's more common to submit on enter or shift + enter. Can switch the logic around if needed.