### PR TITLE
Add delete buttons for task ratings

### DIFF
--- a/frontend/src/components/RatingTable.module.scss
+++ b/frontend/src/components/RatingTable.module.scss
@@ -56,12 +56,13 @@
   @extend .typography-h3;
   @extend .layout-row;
   margin-left: auto;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-  width: 70px;
+  width: 90px;
+  gap: 10px;
 
   .value {
-    margin-left: auto;
+    min-width: 30px;
   }
 }
 

--- a/frontend/src/components/RatingTable.tsx
+++ b/frontend/src/components/RatingTable.tsx
@@ -23,6 +23,7 @@ import { TaskRatingDimension } from '../../../shared/types/customTypes';
 import { BusinessIcon, WorkRoundIcon } from './RoleIcons';
 import colors from '../colors.module.scss';
 import css from './RatingTable.module.scss';
+import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 
 const classes = classNames.bind(css);
 
@@ -36,6 +37,7 @@ export type RatingRow = FC<{
   style?: CSSProperties;
   user: UserInfo;
   onEdit: (e: MouseEvent) => void;
+  onDelete: () => void;
 }>;
 
 interface RatingTableDef {
@@ -69,6 +71,7 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
   const [listHeight, setListHeight] = useState(0);
   const typeString =
     type === TaskRatingDimension.BusinessValue ? 'value' : 'complexity';
+  const roadmapId = useSelector(chosenRoadmapIdSelector);
 
   useEffect(() => {
     if (!divRef) return;
@@ -96,6 +99,19 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
         modalProps: {
           task,
           edit: true,
+        },
+      }),
+    );
+  };
+
+  const openDeleteModal = (rating: Taskrating) => {
+    if (!roadmapId) return;
+    dispatch(
+      modalsActions.showModal({
+        modalType: ModalTypes.REMOVE_RATING_MODAL,
+        modalProps: {
+          roadmapId,
+          rating,
         },
       }),
     );
@@ -139,6 +155,7 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
             rating={ratings[index]}
             user={userInfo}
             onEdit={openRateModal}
+            onDelete={() => openDeleteModal(ratings[index])}
           />
         )}
       </VariableSizeList>

--- a/frontend/src/components/RatingTableComplexity.tsx
+++ b/frontend/src/components/RatingTableComplexity.tsx
@@ -1,14 +1,19 @@
 import classNames from 'classnames';
 import BuildSharpIcon from '@mui/icons-material/BuildSharp';
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useTranslation } from 'react-i18next';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { ratingTable, RatingRow } from './RatingTable';
-import { EditButton } from './forms/SvgButton';
-import { TaskRatingDimension } from '../../../shared/types/customTypes';
+import { EditButton, DeleteButton } from './forms/SvgButton';
+import {
+  TaskRatingDimension,
+  Permission,
+} from '../../../shared/types/customTypes';
 import css from './RatingTable.module.scss';
 import { apiV2, selectById } from '../api/api';
+import { userRoleSelector } from '../redux/user/selectors';
+import { hasPermission } from '../../../shared/utils/permission';
 
 const classes = classNames.bind(css);
 
@@ -22,12 +27,18 @@ const TableComplexityRatingRow: RatingRow = ({
   style,
   user,
   onEdit,
+  onDelete,
 }) => {
   const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: createdBy } = apiV2.useGetRoadmapUsersQuery(
     roadmapId ?? skipToken,
     selectById(rating.createdByUser),
+  );
+  const role = useSelector(userRoleSelector, shallowEqual);
+  const hasEditOthersPermission = hasPermission(
+    role,
+    Permission.TaskRatingEditOthers,
   );
 
   return (
@@ -40,6 +51,7 @@ const TableComplexityRatingRow: RatingRow = ({
           {createdBy?.email ?? `<${t('deleted account')}>`}
         </div>
         <div className={classes(css.rightSide)}>
+          {hasEditOthersPermission && <DeleteButton onClick={onDelete} />}
           {rating.createdByUser === user.id && (
             <EditButton fontSize="medium" onClick={onEdit} />
           )}

--- a/frontend/src/components/modals/ModalRoot.tsx
+++ b/frontend/src/components/modals/ModalRoot.tsx
@@ -13,6 +13,7 @@ import { AddVersionModal } from './AddVersionModal';
 import { DeleteVersionModal, DeleteRoadmapModal } from './DeleteModal';
 import { EditVersionModal } from './EditVersionModal';
 import { RemoveTaskModal } from './RemoveTaskModal';
+import { RemoveRatingModal } from './RemoveRatingModal';
 import { ImportTasksModal } from './ImportTasksModal';
 import { OauthModal } from './IntegrationOauthModal';
 import { IntegrationConfigurationModal } from './IntegrationConfigurationModal';
@@ -38,6 +39,7 @@ const Modals: { readonly [T in ModalTypes]: Modal<T> } = {
   [ModalTypes.RATE_TASK_MODAL]: RateTaskModal,
   [ModalTypes.REMOVE_TASK_MODAL]: RemoveTaskModal,
   [ModalTypes.REMOVE_PEOPLE_MODAL]: RemovePeopleModal,
+  [ModalTypes.REMOVE_RATING_MODAL]: RemoveRatingModal,
   [ModalTypes.EDIT_CUSTOMER_MODAL]: EditCustomerModal,
   [ModalTypes.ADD_CUSTOMER_MODAL]: AddCustomerModal,
   [ModalTypes.ADD_TEAM_MEMBER_MODAL]: AddTeamMemberModal,

--- a/frontend/src/components/modals/RemoveRatingModal.tsx
+++ b/frontend/src/components/modals/RemoveRatingModal.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useState } from 'react';
 import Alert from '@mui/material/Alert';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Modal, ModalTypes } from './types';
@@ -17,6 +17,7 @@ export const RemoveRatingModal: Modal<ModalTypes.REMOVE_RATING_MODAL> = ({
   roadmapId,
   rating,
 }) => {
+  const { t } = useTranslation();
   const [errorMessage, setErrorMessage] = useState('');
   const [
     deleteTaskratingTrigger,
@@ -47,7 +48,6 @@ export const RemoveRatingModal: Modal<ModalTypes.REMOVE_RATING_MODAL> = ({
     }
   };
 
-  if (!customer) return null;
   return (
     <form onSubmit={handleSubmit}>
       <ModalHeader closeModal={closeModal}>
@@ -59,13 +59,22 @@ export const RemoveRatingModal: Modal<ModalTypes.REMOVE_RATING_MODAL> = ({
         <div className="modalCancelContent">
           <AlertIcon />
           <div>
-            <Trans
-              i18nKey="Remove rating warning"
-              values={{
-                rater: rater?.email ?? 'deleted user',
-                customer: customer.name,
-              }}
-            />
+            {customer ? (
+              <Trans
+                i18nKey="Remove representative rating warning"
+                values={{
+                  rater: rater?.email ?? t('deleted account'),
+                  customer: customer.name,
+                }}
+              />
+            ) : (
+              <Trans
+                i18nKey="Remove developer rating warning"
+                values={{
+                  rater: rater?.email ?? t('deleted account'),
+                }}
+              />
+            )}
           </div>
         </div>
         {errorMessage.length > 0 && (

--- a/frontend/src/components/modals/RemoveRatingModal.tsx
+++ b/frontend/src/components/modals/RemoveRatingModal.tsx
@@ -1,0 +1,103 @@
+import { FormEvent, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import { Trans } from 'react-i18next';
+import { skipToken } from '@reduxjs/toolkit/query/react';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { Modal, ModalTypes } from './types';
+import { ModalContent } from './modalparts/ModalContent';
+import { ModalFooter } from './modalparts/ModalFooter';
+import { ModalFooterButtonDiv } from './modalparts/ModalFooterButtonDiv';
+import { ModalHeader } from './modalparts/ModalHeader';
+import { ReactComponent as AlertIcon } from '../../icons/alert_icon.svg';
+import '../../shared.scss';
+import { apiV2, selectById } from '../../api/api';
+
+export const RemoveRatingModal: Modal<ModalTypes.REMOVE_RATING_MODAL> = ({
+  closeModal,
+  roadmapId,
+  rating,
+}) => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [
+    deleteTaskratingTrigger,
+    { isLoading },
+  ] = apiV2.useDeleteTaskratingMutation();
+
+  const { data: rater } = apiV2.useGetRoadmapUsersQuery(
+    roadmapId ?? skipToken,
+    selectById(rating.createdByUser),
+  );
+  const { data: customer } = apiV2.useGetCustomersQuery(
+    roadmapId ?? skipToken,
+    selectById(rating.forCustomer),
+  );
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setErrorMessage('');
+    try {
+      await deleteTaskratingTrigger({
+        roadmapId,
+        rating,
+      }).unwrap();
+      closeModal();
+    } catch (err: any) {
+      setErrorMessage(err.data?.message ?? err.data ?? 'something went wrong');
+    }
+  };
+
+  if (!customer) return null;
+  return (
+    <form onSubmit={handleSubmit}>
+      <ModalHeader closeModal={closeModal}>
+        <h3>
+          <Trans i18nKey="Remove rating" />
+        </h3>
+      </ModalHeader>
+      <ModalContent>
+        <div className="modalCancelContent">
+          <AlertIcon />
+          <div>
+            <Trans
+              i18nKey="Remove rating warning"
+              values={{
+                rater: rater?.email ?? 'deleted user',
+                customer: customer.name,
+              }}
+            />
+          </div>
+        </div>
+        {errorMessage.length > 0 && (
+          <Alert
+            severity="error"
+            onClose={() => setErrorMessage('')}
+            icon={false}
+          >
+            {errorMessage}
+          </Alert>
+        )}
+      </ModalContent>
+      <ModalFooter>
+        <ModalFooterButtonDiv>
+          <button
+            className="button-large cancel"
+            onClick={() => closeModal()}
+            type="button"
+          >
+            <Trans i18nKey="No, go back" />
+          </button>
+        </ModalFooterButtonDiv>
+        <ModalFooterButtonDiv>
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <button className="button-large" type="submit">
+              <Trans i18nKey="Yes, remove it" />
+            </button>
+          )}
+        </ModalFooterButtonDiv>
+      </ModalFooter>
+    </form>
+  );
+};

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -7,6 +7,7 @@ import {
   Task,
   InfoModalContent,
   CheckableUserWithCustomers,
+  Taskrating,
 } from '../../redux/roadmaps/types';
 import { UserModifyRequest, UserDeleteRequest } from '../../redux/user/types';
 
@@ -15,6 +16,7 @@ export enum ModalTypes {
   RATE_TASK_MODAL = 'RATE_TASK_MODAL',
   REMOVE_TASK_MODAL = 'REMOVE_TASK_MODAL',
   REMOVE_PEOPLE_MODAL = 'REMOVE_PEOPLE_MODAL',
+  REMOVE_RATING_MODAL = 'REMOVE_RATING_MODAL',
   EDIT_CUSTOMER_MODAL = 'EDIT_CUSTOMER_MODAL',
   ADD_CUSTOMER_MODAL = 'ADD_CUSTOMER_MODAL',
   ADD_TEAM_MEMBER_MODAL = 'ADD_TEAM_MEMBER_MODAL',
@@ -46,6 +48,10 @@ type OwnProps = {
     id: number | string;
     name: string;
     type: 'customer' | 'team' | 'invitation';
+  };
+  [ModalTypes.REMOVE_RATING_MODAL]: {
+    roadmapId: number;
+    rating: Taskrating;
   };
   [ModalTypes.SEND_INVITATION_MODAL]: {
     invitation: Invitation;

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -247,6 +247,8 @@ export const english = {
     'Remove task': 'Remove task',
     'Remove task warning':
       'Are you sure you want to remove <strong>{{name}}</strong>?',
+    'Remove rating warning':
+      'Are you sure you want to remove rating by <strong>{{rater}}</strong> for <strong>{{customer}}</strong>?',
     'Leave roadmap warning':
       'Are you sure you want to leave roadmap <strong>{{name}}</strong>?',
     'Leave roadmap warning last admin':

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -247,8 +247,10 @@ export const english = {
     'Remove task': 'Remove task',
     'Remove task warning':
       'Are you sure you want to remove <strong>{{name}}</strong>?',
-    'Remove rating warning':
+    'Remove representative rating warning':
       'Are you sure you want to remove rating by <strong>{{rater}}</strong> for <strong>{{customer}}</strong>?',
+    'Remove developer rating warning':
+      'Are you sure you want to remove rating by <strong>{{rater}}</strong>?',
     'Leave roadmap warning':
       'Are you sure you want to leave roadmap <strong>{{name}}</strong>?',
     'Leave roadmap warning last admin':

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -139,7 +139,7 @@ export const MainRouter = () => {
 
     dispatch(
       modalsActions.showModal({
-        modalType: queryModal as ModalTypes,
+        modalType: queryModal as any,
         modalProps: queryProps as any,
       }),
     );


### PR DESCRIPTION
User with Permission.TaskRatingEditOthers (so admin) can delete any ratings from task overview page.

Adds delete-icons to task overview page and upon clicking them it opens a modal to confirm the deletion. 