### PR TITLE
Hide sidebar when roadmap invalid and redirect properly

### DIFF
--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -14,6 +14,7 @@ import css from './RoadmapSidebar.module.scss';
 import { userRoleSelector } from '../redux/user/selectors';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { RoleType } from '../../../shared/types/customTypes';
+import { apiV2, selectById } from '../api/api';
 
 const classes = classNames.bind(css);
 
@@ -21,10 +22,14 @@ export const RoadmapSidebar: FC = () => {
   const { pathname } = useLocation();
   const role = useSelector(userRoleSelector, shallowEqual);
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-
-  if (roadmapId === undefined) return null;
+  const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(
+    undefined,
+    selectById(roadmapId),
+  );
 
   const url = `/roadmap/${roadmapId}`;
+
+  if (!roadmapId || (!roadmap && !isFetching)) return null;
 
   const renderButtons = () => {
     return (

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -22,6 +22,7 @@ import { PlannerPageRouter } from './PlannerPageRouter';
 import { TasksPageRouter } from './TasksPageRouter';
 import '../shared.scss';
 import { usePrevious } from '../utils/usePrevious';
+import { apiV2, selectById } from '../api/api';
 
 const routes = [
   {
@@ -68,6 +69,10 @@ const RoadmapRouterComponent = () => {
   const selectedRoadmapId = useSelector(chosenRoadmapIdSelector);
   const previousRoadmapId = usePrevious<number | undefined>(selectedRoadmapId);
   const dispatch = useDispatch<StoreDispatchType>();
+  const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(
+    undefined,
+    selectById(selectedRoadmapId),
+  );
 
   useEffect(() => {
     // Try to select roadmap given in route parameters
@@ -101,12 +106,8 @@ const RoadmapRouterComponent = () => {
     urlRoadmapId,
   ]);
 
-  if (!selectedRoadmapId)
-    return (
-      <div className="layoutRow">
-        <div className="layoutCol">Roadmap not found!</div>
-      </div>
-    );
+  if (selectedRoadmapId && !isFetching && !roadmap)
+    return <Redirect to={paths.notFound} />;
 
   return (
     <div className="layoutRow overflowYAuto">


### PR DESCRIPTION
Roadmaprouter used to show "Roadmap not found" instead of properly redirecting when roadmap was not defined. Now it properly tries to load a roadmap first and redirects to 404 if it doesnt find it.

Sidebar is also hidden now unless a valid roadmap is open.