### PR TITLE
Fix RateTaskModal loading issue.

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -150,7 +150,7 @@ export const apiV2 = createApi({
     addTask: build.mutation<Task, { roadmapId: number; task: TaskRequest }>({
       invalidatesTags: ['Tasks'],
       query: ({ roadmapId, task }) => ({
-        url: `roadmaps/${roadmapId}/tasks/`,
+        url: `roadmaps/${roadmapId}/tasks?eager=1`,
         method: 'post',
         data: task,
       }),

--- a/frontend/src/components/RatingTable.tsx
+++ b/frontend/src/components/RatingTable.tsx
@@ -10,7 +10,7 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { VariableSizeList } from 'react-window';
 import classNames from 'classnames';
-import { Taskrating } from '../redux/roadmaps/types';
+import { Task, Taskrating } from '../redux/roadmaps/types';
 import { FilterTypes } from '../utils/TaskUtils';
 import { titleCase } from '../utils/string';
 import { StoreDispatchType } from '../redux';
@@ -44,7 +44,7 @@ interface RatingTableDef {
 }
 
 type RatingTableProps = {
-  taskId: number;
+  task: Task;
   ratings: Taskrating[];
   avg: number;
   searchFilter?: FilterTypes;
@@ -55,7 +55,7 @@ type RatingTableProps = {
 export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
   Row,
   type,
-}) => ({ taskId, ratings, avg, height = 500 }) => {
+}) => ({ task, ratings, avg, height = 500 }) => {
   const dispatch = useDispatch<StoreDispatchType>();
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,
@@ -94,7 +94,7 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
       modalsActions.showModal({
         modalType: ModalTypes.RATE_TASK_MODAL,
         modalProps: {
-          taskId,
+          task,
           edit: true,
         },
       }),

--- a/frontend/src/components/TaskModalButtons.tsx
+++ b/frontend/src/components/TaskModalButtons.tsx
@@ -77,7 +77,7 @@ export const TaskModalButtons: FC<{
 
   const openRateModal = openModal({
     modalType: ModalTypes.RATE_TASK_MODAL,
-    modalProps: { taskId: task.id, edit: false },
+    modalProps: { task, edit: false },
   });
 
   const awaitsRatings = awaitsUserRatings(userInfo, roadmapId, customers)(task);

--- a/frontend/src/components/modals/AddTaskModal.tsx
+++ b/frontend/src/components/modals/AddTaskModal.tsx
@@ -58,7 +58,7 @@ export const AddTaskModal: Modal<ModalTypes.ADD_TASK_MODAL> = ({
       };
 
       try {
-        const res = await addTaskTrigger({
+        const task = await addTaskTrigger({
           roadmapId: chosenRoadmapId!,
           task: req,
         }).unwrap();
@@ -68,7 +68,7 @@ export const AddTaskModal: Modal<ModalTypes.ADD_TASK_MODAL> = ({
           modalsActions.showModal({
             modalType: ModalTypes.RATE_TASK_MODAL,
             modalProps: {
-              taskId: res.id,
+              task,
               edit: false,
             },
           }),

--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -2,7 +2,6 @@ import { FC, FormEvent, useState, useEffect } from 'react';
 import Alert from '@mui/material/Alert';
 import { Trans } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
-import { skipToken } from '@reduxjs/toolkit/query/react';
 import classNames from 'classnames';
 import { chosenRoadmapIdSelector } from '../../redux/roadmaps/selectors';
 import {
@@ -27,7 +26,7 @@ import { ModalHeader } from './modalparts/ModalHeader';
 import { Dot } from '../Dot';
 import { getType } from '../../utils/UserUtils';
 import css from './RateTaskModal.module.scss';
-import { apiV2, selectById } from '../../api/api';
+import { apiV2 } from '../../api/api';
 
 const classes = classNames.bind(css);
 
@@ -67,9 +66,10 @@ const CustomerHeader: FC<{
 
 export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
   closeModal,
-  taskId,
+  task,
   edit,
 }) => {
+  console.log('task modaalissa:', task);
   const [errorMessage, setErrorMessage] = useState('');
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,
@@ -80,17 +80,12 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
   const [patchTaskratings, patchStatus] = apiV2.usePatchTaskratingsMutation();
   const [addTaskratings, addStatus] = apiV2.useAddTaskratingsMutation();
 
-  const { data: task } = apiV2.useGetTasksQuery(
-    roadmapId ?? skipToken,
-    selectById(taskId),
-  );
-
   const dimension =
     getType(userInfo, roadmapId) === RoleType.Developer
       ? TaskRatingDimension.Complexity
       : TaskRatingDimension.BusinessValue;
 
-  const taskRatings = task?.ratings.filter(
+  const taskRatings = task.ratings.filter(
     (rating) =>
       rating.createdByUser === userInfo?.id && rating.dimension === dimension,
   );
@@ -167,7 +162,7 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
     const action = edit ? patchTaskratings : addTaskratings;
     if (roadmapId === undefined || changed.length === 0) return;
     try {
-      await action({ roadmapId, ratings: changed, taskId }).unwrap();
+      await action({ roadmapId, ratings: changed, taskId: task.id }).unwrap();
       closeModal();
     } catch (err: any) {
       setErrorMessage(err.data?.message ?? err.data ?? 'something went wrong');

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -40,7 +40,7 @@ export enum ModalTypes {
 
 type OwnProps = {
   [ModalTypes.ADD_TASK_MODAL]: {};
-  [ModalTypes.RATE_TASK_MODAL]: { taskId: number; edit: boolean };
+  [ModalTypes.RATE_TASK_MODAL]: { task: Task; edit: boolean };
   [ModalTypes.REMOVE_TASK_MODAL]: { task: Task };
   [ModalTypes.REMOVE_PEOPLE_MODAL]: {
     id: number | string;

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -175,14 +175,14 @@ const TaskOverview: FC<{
             <RatingTableValue
               ratings={valueRatings}
               avg={value.avg}
-              taskId={task.id}
+              task={task}
             />
           )}
           {complexityRatings.length > 0 && (
             <RatingTableComplexity
               ratings={complexityRatings}
               avg={complexity.avg}
-              taskId={task.id}
+              task={task}
             />
           )}
         </div>


### PR DESCRIPTION
Rate task modal tried to apply task ratings to the businessValueRatings state before fetching task correctly. This only happened when you tried giving ratings from the task modal that opens automatically after creating a new task.

I changed the parameters from TaskId to Task, this way the task can't be either loading or undefined.