### PR TITLE
Query fixes

### DIFF
--- a/frontend/src/components/RoadmapOverview.tsx
+++ b/frontend/src/components/RoadmapOverview.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -9,14 +9,28 @@ import { averageValueAndComplexity } from '../utils/TaskUtils';
 import { MetricsSummary } from './MetricsSummary';
 import colors from '../colors.module.scss';
 import { apiV2 } from '../api/api';
+import { Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
+import { getType } from '../utils/UserUtils';
+import { UserInfo } from '../redux/user/types';
+import { userInfoSelector } from '../redux/user/selectors';
+import { RootState } from '../redux/types';
 
 const classes = classNames.bind(css);
 
 export const RoadmapOverview = () => {
   const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const type = getType(userInfo, roadmapId);
   const { data: roadmapsVersions } = apiV2.useGetVersionsQuery(
     roadmapId ?? skipToken,
+    {
+      skip: !hasPermission(type, Permission.VersionRead),
+    },
   );
   const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
 

--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -22,14 +22,13 @@ export const RoadmapSidebar: FC = () => {
   const { pathname } = useLocation();
   const role = useSelector(userRoleSelector, shallowEqual);
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(
-    undefined,
-    selectById(roadmapId),
-  );
+  const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(undefined, {
+    ...selectById(roadmapId),
+    skip: !roadmapId,
+  });
+  if (!roadmapId || (!roadmap && !isFetching)) return null;
 
   const url = `/roadmap/${roadmapId}`;
-
-  if (!roadmapId || (!roadmap && !isFetching)) return null;
 
   const renderButtons = () => {
     return (

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -6,7 +6,7 @@ import {
   DropResult,
 } from 'react-beautiful-dnd';
 import { Trans, useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import classNames from 'classnames';
 import InfoIcon from '@mui/icons-material/InfoOutlined';
@@ -30,6 +30,12 @@ import { InfoTooltip } from '../components/InfoTooltip';
 import css from './MilestonesEditor.module.scss';
 import { apiV2 } from '../api/api';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
+import { getType } from '../utils/UserUtils';
+import { UserInfo } from '../redux/user/types';
+import { userInfoSelector } from '../redux/user/selectors';
+import { RootState } from '../redux/types';
 
 const classes = classNames.bind(css);
 
@@ -59,8 +65,16 @@ export const MilestonesEditor = () => {
     patchVersion,
     { isLoading: disableDrag, isError },
   ] = apiV2.usePatchVersionMutation();
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const type = getType(userInfo, roadmapId);
   const { data: roadmapsVersions } = apiV2.useGetVersionsQuery(
     roadmapId ?? skipToken,
+    {
+      skip: !hasPermission(type, Permission.VersionRead),
+    },
   );
   const { data: customers } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 
 import classNames from 'classnames';
@@ -17,6 +17,12 @@ import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { Version } from '../redux/roadmaps/types';
 import colors from '../colors.module.scss';
 import { apiV2 } from '../api/api';
+import { Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
+import { getType } from '../utils/UserUtils';
+import { UserInfo } from '../redux/user/types';
+import { userInfoSelector } from '../redux/user/selectors';
+import { RootState } from '../redux/types';
 
 const classes = classNames.bind(css);
 
@@ -35,8 +41,16 @@ export const RoadmapGraphPage = () => {
     undefined | VersionComplexityAndValues[]
   >(undefined);
   const roadmapId = useSelector(chosenRoadmapIdSelector);
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const type = getType(userInfo, roadmapId);
   const { data: roadmapsVersions } = apiV2.useGetVersionsQuery(
     roadmapId ?? skipToken,
+    {
+      skip: !hasPermission(type, Permission.VersionRead),
+    },
   );
   const { data: customers } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,

--- a/frontend/src/pages/TimeEstimationPage.tsx
+++ b/frontend/src/pages/TimeEstimationPage.tsx
@@ -20,6 +20,11 @@ import { Dropdown } from '../components/forms/Dropdown';
 import { modalsActions } from '../redux/modals';
 import { ModalTypes } from '../components/modals/types';
 import { apiV2 } from '../api/api';
+import { Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
+import { getType } from '../utils/UserUtils';
+import { UserInfo } from '../redux/user/types';
+import { userInfoSelector } from '../redux/user/selectors';
 
 const classes = classNames.bind(css);
 
@@ -27,8 +32,16 @@ export const TimeEstimationPage = () => {
   const { t } = useTranslation();
   const durationInput = useRef<HTMLInputElement>(null);
   const roadmapId = useSelector(chosenRoadmapIdSelector);
+  const userInfo = useSelector<RootState, UserInfo | undefined>(
+    userInfoSelector,
+    shallowEqual,
+  );
+  const type = getType(userInfo, roadmapId);
   const { data: roadmapsVersions } = apiV2.useGetVersionsQuery(
     roadmapId ?? skipToken,
+    {
+      skip: !hasPermission(type, Permission.VersionRead),
+    },
   );
   const dispatch = useDispatch<StoreDispatchType>();
   const timeEstimates = useSelector<RootState, TimeEstimate[]>(


### PR DESCRIPTION
Skip version queries if logged in user does not have permssion to query versions
(this used to create a failed query with status 403 every time certain components rendered on non-admins)

Skip roadmapsidebar roadmaps query if there is no logged in user
(this used to spam failed queries on login page)