### PR TITLE
Make selectedRoadmapId nullable, set to null on 404

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -36,7 +36,7 @@ export const NavBar = () => {
           <VisdomLogo />
         </div>
       )}
-      {pathname.startsWith(paths.userInfo) && roadmapId === undefined && (
+      {pathname.startsWith(paths.userInfo) && !roadmapId && (
         <Link to={paths.overview} className={classes(css.logo)}>
           <VisdomLogo />
         </Link>

--- a/frontend/src/components/TableCustomerRow.tsx
+++ b/frontend/src/components/TableCustomerRow.tsx
@@ -38,7 +38,7 @@ export const TableCustomerRow: TableRow<Customer> = ({
   );
 
   useEffect(() => {
-    if (roadmapId !== undefined && tasks)
+    if (roadmapId && tasks)
       setUnratedAmount(
         unratedTasksAmount(customer, roadmapId, tasks, users, customers),
       );

--- a/frontend/src/components/TaskMapEdge.tsx
+++ b/frontend/src/components/TaskMapEdge.tsx
@@ -37,7 +37,7 @@ const DrawPath: FC<DrawPathProps> = ({
   // Should be given 'id' as param in the form: 'from-taskId-to-taskId'
   const deleteRelation = useCallback(
     async (tbdeleted: string) => {
-      if (roadmapId === undefined) return;
+      if (!roadmapId) return;
       if (isLoading) return;
       const data = tbdeleted.split('-');
       setIsLoading(true);

--- a/frontend/src/components/TaskRelationTable.tsx
+++ b/frontend/src/components/TaskRelationTable.tsx
@@ -148,7 +148,7 @@ const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
         value={null}
         escapeClearsValue
         onChange={(selected) => {
-          if (selected && roadmapId !== undefined) {
+          if (selected && roadmapId) {
             addTaskRelation({
               roadmapId,
               relation: buildRelation(task.id, selected.value),
@@ -182,7 +182,7 @@ const relationTable: (def: RelationTableDef) => FC<RelationTableProps> = ({
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    if (roadmapId !== undefined) {
+                    if (roadmapId) {
                       removeTaskRelation({
                         roadmapId,
                         relation: buildRelation(task.id, id),

--- a/frontend/src/components/modals/AddCustomerModal.tsx
+++ b/frontend/src/components/modals/AddCustomerModal.tsx
@@ -58,7 +58,7 @@ export const AddCustomerModal: Modal<ModalTypes.ADD_CUSTOMER_MODAL> = ({
   }, [roadmapUsers]);
 
   const handleSubmit = async () => {
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     try {
       await addCustomerTrigger({
         roadmapId,

--- a/frontend/src/components/modals/AddTaskModal.tsx
+++ b/frontend/src/components/modals/AddTaskModal.tsx
@@ -32,9 +32,7 @@ export const AddTaskModal: Modal<ModalTypes.ADD_TASK_MODAL> = ({
   });
   const [errorMessage, setErrorMessage] = useState('');
   const [addTaskTrigger, { isLoading }] = apiV2.useAddTaskMutation();
-  const chosenRoadmapId = useSelector<RootState, number | undefined>(
-    chosenRoadmapIdSelector,
-  );
+  const chosenRoadmapId = useSelector(chosenRoadmapIdSelector);
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,
     shallowEqual,
@@ -53,7 +51,7 @@ export const AddTaskModal: Modal<ModalTypes.ADD_TASK_MODAL> = ({
       const req: TaskRequest = {
         name: formValues.name,
         description: formValues.description,
-        roadmapId: chosenRoadmapId,
+        roadmapId: chosenRoadmapId!,
         createdByUser: userInfo?.id,
       };
 

--- a/frontend/src/components/modals/AddTeamMemberModal.tsx
+++ b/frontend/src/components/modals/AddTeamMemberModal.tsx
@@ -59,7 +59,7 @@ export const AddTeamMemberModal: Modal<ModalTypes.ADD_TEAM_MEMBER_MODAL> = ({
     event.preventDefault();
     event.stopPropagation();
 
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
 
     try {
       await sendInvitation({

--- a/frontend/src/components/modals/AddVersionModal.tsx
+++ b/frontend/src/components/modals/AddVersionModal.tsx
@@ -27,7 +27,7 @@ export const AddVersionModal: Modal<ModalTypes.ADD_VERSION_MODAL> = ({
     event.preventDefault();
     event.stopPropagation();
 
-    if (!form.checkValidity() || roadmapId === undefined) return;
+    if (!form.checkValidity() || !roadmapId) return;
 
     try {
       await addVersion({ roadmapId, name: versionName }).unwrap();

--- a/frontend/src/components/modals/EditCustomerModal.tsx
+++ b/frontend/src/components/modals/EditCustomerModal.tsx
@@ -79,7 +79,7 @@ export const EditCustomerModal: Modal<ModalTypes.EDIT_CUSTOMER_MODAL> = ({
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     patchCustomerTrigger({
       roadmapId,
       customer: {

--- a/frontend/src/components/modals/EditTeamMemberModal.tsx
+++ b/frontend/src/components/modals/EditTeamMemberModal.tsx
@@ -67,7 +67,7 @@ export const EditTeamMemberModal: Modal<ModalTypes.EDIT_TEAM_MEMBER_MODAL> = ({
   }, [selectedRole]);
 
   const editInvitation = async () => {
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     try {
       await patchInvitation({
         roadmapId,
@@ -85,7 +85,7 @@ export const EditTeamMemberModal: Modal<ModalTypes.EDIT_TEAM_MEMBER_MODAL> = ({
   };
 
   const editTeamMember = async () => {
-    if (roadmapId === undefined || member.type === selectedRole) return;
+    if (!roadmapId || member.type === selectedRole) return;
 
     try {
       await patchRoadmapUser({

--- a/frontend/src/components/modals/EditVersionModal.tsx
+++ b/frontend/src/components/modals/EditVersionModal.tsx
@@ -31,7 +31,7 @@ export const EditVersionModal: Modal<ModalTypes.EDIT_VERSION_MODAL> = ({
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     try {
       await patchVersion({ roadmapId, id, name: newName }).unwrap();
       closeModal();

--- a/frontend/src/components/modals/ImportTasksModal.tsx
+++ b/frontend/src/components/modals/ImportTasksModal.tsx
@@ -42,7 +42,7 @@ export const ImportTasksModal: Modal<ModalTypes.IMPORT_TASKS_MODAL> = ({
       name,
       roadmapId: chosenRoadmapId!,
     },
-    { skip: chosenRoadmapId === undefined },
+    { skip: !chosenRoadmapId },
   );
   const labels = apiV2.useGetIntegrationBoardLabelsQuery(
     {
@@ -50,7 +50,7 @@ export const ImportTasksModal: Modal<ModalTypes.IMPORT_TASKS_MODAL> = ({
       boardId: selectedBoardId!,
       roadmapId: chosenRoadmapId!,
     },
-    { skip: !selectedBoardId || chosenRoadmapId === undefined },
+    { skip: !selectedBoardId || !chosenRoadmapId },
   );
   const userInfo = useSelector<RootState, UserInfo | undefined>(
     userInfoSelector,

--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -160,7 +160,7 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
 
     const changed = businessValueRatings.filter((rating) => rating.changed);
     const action = edit ? patchTaskratings : addTaskratings;
-    if (roadmapId === undefined || changed.length === 0) return;
+    if (!roadmapId || changed.length === 0) return;
     try {
       await action({ roadmapId, ratings: changed, taskId: task.id }).unwrap();
       closeModal();

--- a/frontend/src/pages/ClientOverviewPage.tsx
+++ b/frontend/src/pages/ClientOverviewPage.tsx
@@ -47,7 +47,7 @@ const ClientOverview: FC<{
   });
   const { data: users } = apiV2.useGetRoadmapUsersQuery(roadmapId ?? skipToken);
 
-  if (roadmapId === undefined) return null;
+  if (!roadmapId) return null;
   const unratedTasks = unratedTasksAmount(
     client,
     roadmapId,

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -40,7 +40,7 @@ const RoadmapConfigurationPageComponent = ({
   const onConfigurationClick = (target: string, fields: any[]) => (e: any) => {
     e.preventDefault();
 
-    if (!roadmap || roadmapId === undefined) return;
+    if (!roadmap || !roadmapId) return;
     const configuration = roadmap.integrations.find(
       ({ name }) => name === target,
     );
@@ -60,7 +60,7 @@ const RoadmapConfigurationPageComponent = ({
 
   const onOAuthClick = (target: string) => (e: any) => {
     e.preventDefault();
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     dispatch(
       modalsActions.showModal({
         modalType: ModalTypes.SETUP_OAUTH_MODAL,
@@ -80,7 +80,7 @@ const RoadmapConfigurationPageComponent = ({
   };
   const openDeleteRoadmapModal = (e: any) => {
     e.preventDefault();
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     dispatch(
       modalsActions.showModal({
         modalType: ModalTypes.DELETE_ROADMAP_MODAL,

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -123,7 +123,7 @@ export const MilestonesEditor = () => {
   const deleteVersionClicked = (id: number) => (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     dispatch(
       modalsActions.showModal({
         modalType: ModalTypes.DELETE_VERSION_MODAL,
@@ -153,7 +153,7 @@ export const MilestonesEditor = () => {
   };
 
   const onDragReorder = async (result: DropWithDestination) => {
-    if (roadmapId === undefined) return;
+    if (!roadmapId) return;
     const { source, destination } = result;
     const copyLists = copyVersionLists(versionLists);
 
@@ -208,7 +208,7 @@ export const MilestonesEditor = () => {
   };
 
   const onVersionDragEnd = async (result: DropWithDestination) => {
-    if (roadmapId === undefined || roadmapsVersions === undefined) return;
+    if (!roadmapId || roadmapsVersions === undefined) return;
     const { source, destination, draggableId } = result;
     const dragVersionId = parseInt(draggableId.match(/\d+/)![0], 10);
     const versionsCopy = roadmapsVersions

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -10,6 +10,7 @@ import { ModalContent } from '../components/modals/modalparts/ModalContent';
 import { ModalHeader } from '../components/modals/modalparts/ModalHeader';
 import { Footer } from '../components/Footer';
 import '../shared.scss';
+import { roadmapsActions } from '../redux/roadmaps';
 
 export const NotFoundPage = () => {
   const dispatch = useDispatch<StoreDispatchType>();
@@ -19,6 +20,8 @@ export const NotFoundPage = () => {
   useEffect(() => {
     if (!loadedUserInfo)
       dispatch(userActions.getUserInfo()).then(() => setLoadedUserInfo(true));
+
+    dispatch(roadmapsActions.selectCurrentRoadmap(null));
   }, [dispatch, loadedUserInfo]);
 
   if (!loadedUserInfo) return <LoadingSpinner />;

--- a/frontend/src/pages/PlannerWeightsPage.tsx
+++ b/frontend/src/pages/PlannerWeightsPage.tsx
@@ -41,7 +41,7 @@ export const PlannerWeightsPage = () => {
   };
 
   const saveWeight = async (customerId: number, weight: number) => {
-    if (roadmapId !== undefined)
+    if (roadmapId)
       patchCustomerTrigger({ roadmapId, customer: { id: customerId, weight } });
   };
 

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -9,7 +9,7 @@ import {
 import { RoadmapsState } from './types';
 
 const initialState: RoadmapsState = {
-  selectedRoadmapId: undefined,
+  selectedRoadmapId: null,
   taskmapPosition: undefined,
 };
 

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -3,7 +3,7 @@ import { RoadmapsState, TaskmapPosition } from './types';
 
 export const SELECT_CURRENT_ROADMAP: CaseReducer<
   RoadmapsState,
-  PayloadAction<number>
+  PayloadAction<number | null>
 > = (state, action) => {
   state.selectedRoadmapId = action.payload;
 };

--- a/frontend/src/redux/roadmaps/selectors.ts
+++ b/frontend/src/redux/roadmaps/selectors.ts
@@ -1,6 +1,6 @@
 import { RootState } from '../types';
 
-export const chosenRoadmapIdSelector = (state: RootState): number | undefined =>
+export const chosenRoadmapIdSelector = (state: RootState) =>
   state.roadmaps.selectedRoadmapId;
 
 export const taskmapPositionSelector = (state: RootState) =>

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../shared/types/customTypes';
 
 export interface RoadmapsState {
-  selectedRoadmapId?: number;
+  selectedRoadmapId?: number | null;
   taskmapPosition: TaskmapPosition | undefined;
 }
 

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -67,7 +67,9 @@ const RoadmapRouterComponent = () => {
     roadmapId: string | undefined;
   }>();
   const selectedRoadmapId = useSelector(chosenRoadmapIdSelector);
-  const previousRoadmapId = usePrevious<number | undefined>(selectedRoadmapId);
+  const previousRoadmapId = usePrevious<number | undefined | null>(
+    selectedRoadmapId,
+  );
   const dispatch = useDispatch<StoreDispatchType>();
   const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(
     undefined,
@@ -87,7 +89,7 @@ const RoadmapRouterComponent = () => {
     let newPath: string;
     const roadmapIdRegex = new RegExp('^/roadmap/\\d+/');
     if (!previousRoadmapId || selectedRoadmapId === previousRoadmapId) return;
-    if (selectedRoadmapId === undefined) {
+    if (!selectedRoadmapId) {
       newPath = '/overview';
     } else if (history.location.pathname.match(roadmapIdRegex)) {
       newPath = history.location.pathname.replace(

--- a/frontend/src/utils/SortCustomerUtils.ts
+++ b/frontend/src/utils/SortCustomerUtils.ts
@@ -12,7 +12,7 @@ export enum CustomerSortingTypes {
 }
 
 export const customerSort = (
-  roadmapId?: number,
+  roadmapId?: number | null,
   tasks?: Task[],
   users?: RoadmapUser[],
   customers?: Customer[],
@@ -27,7 +27,7 @@ export const customerSort = (
     case CustomerSortingTypes.SORT_COLOR:
       return sortKeyLocale('color');
     case CustomerSortingTypes.SORT_UNRATED:
-      return roadmapId === undefined
+      return !roadmapId
         ? undefined
         : sortKeyNumeric((customer) =>
             unratedTasksAmount(

--- a/frontend/src/utils/SortRoadmapUserUtils.ts
+++ b/frontend/src/utils/SortRoadmapUserUtils.ts
@@ -10,7 +10,7 @@ export enum UserSortingTypes {
 }
 
 export const userSort = (
-  roadmapId?: number,
+  roadmapId?: number | null,
   tasks?: Task[],
   customers?: Customer[],
 ) => (type: UserSortingTypes | undefined): SortBy<RoadmapUser> => {

--- a/frontend/src/utils/UserUtils.ts
+++ b/frontend/src/utils/UserUtils.ts
@@ -7,7 +7,7 @@ export const isUserInfo = (
 
 export const getType = (
   user: UserInfo | RoadmapUser | undefined,
-  roadmapId: number | undefined,
+  roadmapId: number | undefined | null,
 ) => {
   if (!user) return undefined;
   if (isUserInfo(user))


### PR DESCRIPTION
https://trello.com/c/kbrJoN6F/520-fix-404-sivun-tyylit-kun-roadmap-on-auki

Made roadmapId nullable, also made 404 page deselect roadmap in order to hide sidebar as the trello card proposed. Returning to a previously valid roadmap still works with the browsers back button.