### PR TITLE
Add format for multiline text in EditableText

### DIFF
--- a/frontend/src/components/EditableText.module.scss
+++ b/frontend/src/components/EditableText.module.scss
@@ -33,6 +33,9 @@
     @extend .NOT_STARTED;
     color: $COLOR_FOREST;
   }
+  &.multiline {
+    white-space: pre-line;
+  }
 }
 
 .input {

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -103,6 +103,7 @@ export const getTaskOverviewData = (
         label: i18n.t('Description'),
         keyName: 'description',
         value: task.description,
+        format: 'multiline',
         editable,
       },
     ],


### PR DESCRIPTION
For example, "format: 'multiline'" can be passed to data in overviews.

https://trello.com/c/wMOi6X6N/598-taskoverview-description-render%C3%B6i-newlinet