### PR TITLE
Clear taskrating

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -165,7 +165,7 @@ export const apiV2 = createApi({
         method: 'delete',
       }),
     }),
-    patchTaskratings: build.mutation<
+    updateTaskratings: build.mutation<
       Taskrating[],
       { roadmapId: number; taskId: number; ratings: TaskratingRequest[] }
     >({

--- a/frontend/src/components/RatingBars.tsx
+++ b/frontend/src/components/RatingBars.tsx
@@ -38,7 +38,12 @@ export const TaskRatingBar: FC<RatingBarProps> = ({
         value={initialValue}
         max={5}
         onChange={(_, value) => {
-          if (onChange && value) onChange(value);
+          if (!onChange) return;
+          if (value) onChange(value);
+          else {
+            onChange(0);
+            setHover(0);
+          }
         }}
         onChangeActive={(_, value) => setHover(value)}
         icon={getIcon()}

--- a/frontend/src/components/modals/RateTaskModal.tsx
+++ b/frontend/src/components/modals/RateTaskModal.tsx
@@ -76,7 +76,10 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
   );
   const roadmapId = useSelector(chosenRoadmapIdSelector);
 
-  const [patchTaskratings, patchStatus] = apiV2.usePatchTaskratingsMutation();
+  const [
+    updateTaskratings,
+    updateStatus,
+  ] = apiV2.useUpdateTaskratingsMutation();
   const [addTaskratings, addStatus] = apiV2.useAddTaskratingsMutation();
 
   const dimension =
@@ -146,7 +149,7 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
     event.stopPropagation();
 
     const changed = businessValueRatings.filter((rating) => rating.changed);
-    const action = edit ? patchTaskratings : addTaskratings;
+    const action = edit ? updateTaskratings : addTaskratings;
     if (!roadmapId || changed.length === 0) return;
     try {
       await action({ roadmapId, ratings: changed, taskId: task.id }).unwrap();
@@ -233,7 +236,7 @@ export const RateTaskModal: Modal<ModalTypes.RATE_TASK_MODAL> = ({
       </ModalContent>
       <ModalFooter closeModal={closeModal}>
         <ModalFooterButtonDiv>
-          {patchStatus.isLoading || addStatus.isLoading ? (
+          {updateStatus.isLoading || addStatus.isLoading ? (
             <LoadingSpinner />
           ) : (
             <button

--- a/server/src/api/taskratings/taskratings.routes.ts
+++ b/server/src/api/taskratings/taskratings.routes.ts
@@ -3,7 +3,7 @@ import {
   getTaskratings,
   deleteTaskrating,
   postTaskRatings,
-  patchTaskratings,
+  updateTaskratings,
 } from './taskratings.controller';
 import { requirePermission } from './../../utils/checkPermissions';
 import { Permission } from '../../../../shared/types/customTypes';
@@ -23,7 +23,7 @@ taskratingRouter.post(
 taskratingRouter.patch(
   '/taskratings',
   requirePermission(Permission.TaskRatingEdit),
-  patchTaskratings,
+  updateTaskratings,
 );
 taskratingRouter.delete(
   '/taskratings/:ratingId',

--- a/server/tests/taskratings.test.ts
+++ b/server/tests/taskratings.test.ts
@@ -179,9 +179,9 @@ describe('Test /roadmap/:roadmapId/tasks/:taskId/taskratings/ api', function () 
           },
         ]);
       expect(res.status).to.equal(200);
-      expect(res.body.length).to.equal(1);
-      expect(res.body[0].dimension).to.equal(rating.dimension);
-      expect(res.body[0].value).to.equal(newValue);
+      expect(res.body.updated.length).to.equal(1);
+      expect(res.body.updated[0].dimension).to.equal(rating.dimension);
+      expect(res.body.updated[0].value).to.equal(newValue);
     });
     it('Should not patch taskrating with incorrect permissions', async function () {
       const { rating, taskId, roadmapId } = await getTestRatingData();


### PR DESCRIPTION
Add the possibility to clear ratings in the taskrating modal by re-clicking the current rating
  - If the modal is in edit-mode, the cleared rating will be deleted
  - Otherwise, the cleared rating is not sent on submit

Taskrating deletion is added to the patch-route to handle everything in one transaction
  - If the rating value is zero, it is deleted in the patch-route
  - PatchTaskratings is renamed to updateRaskratings