### PR TITLE
Fix 404-routing of reload of some overview pages

### DIFF
--- a/frontend/src/pages/ClientOverviewPage.tsx
+++ b/frontend/src/pages/ClientOverviewPage.tsx
@@ -18,6 +18,7 @@ import { BusinessIcon } from '../components/RoleIcons';
 import { Dot } from '../components/Dot';
 import { unratedTasksAmount, totalCustomerStakes } from '../utils/TaskUtils';
 import { RepresentativeTable } from '../components/RepresentativeTable';
+import { LoadingSpinner } from '../components/LoadingSpinner';
 import colors from '../colors.module.scss';
 import css from './ClientOverviewPage.module.scss';
 import { apiV2 } from '../api/api';
@@ -147,7 +148,7 @@ const ClientOverview: FC<{
 export const ClientOverviewPage = () => {
   const { clientId } = useParams<{ clientId: string | undefined }>();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const { data: customers } = apiV2.useGetCustomersQuery(
+  const { data: customers, isFetching } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,
   );
   const userInfoCustomers = useSelector<RootState, Customer[]>(
@@ -161,6 +162,7 @@ export const ClientOverviewPage = () => {
   const client =
     clientIdx !== undefined && clientIdx >= 0 ? clients[clientIdx] : undefined;
 
+  if (!roadmapId || isFetching) return <LoadingSpinner />;
   if (!client) return <Redirect to={paths.notFound} />;
   return (
     <ClientOverview clients={clients} client={client} clientIdx={clientIdx} />

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -245,8 +245,9 @@ export const TaskOverviewPage = () => {
   const { data: tasks, isFetching } = apiV2.useGetTasksQuery(
     roadmapId ?? skipToken,
   );
+
   const taskIdx = tasks?.findIndex(({ id }) => Number(taskId) === id);
-  if (isFetching) return <LoadingSpinner />;
+  if (!roadmapId || isFetching) return <LoadingSpinner />;
   if (!tasks || taskIdx === undefined || taskIdx < 0)
     return <Redirect to={paths.notFound} />;
   return <TaskOverview tasks={tasks} task={tasks[taskIdx]} taskIdx={taskIdx} />;


### PR DESCRIPTION
Client and task overview pages routed to 404 on reload. This was due to delay in fetching the chosenRoadmapSelector.

To fix the problem, the page components can show a waiting indicator while the roadmapId is undefined or null. This is possible, since RoamapRouter handles setting the chosenRoadmapId and routing to 404 if it does not exist.