### PR TITLE
Fix roadmapGraph styles

### DIFF
--- a/frontend/src/pages/RoadmapGraphPage.module.scss
+++ b/frontend/src/pages/RoadmapGraphPage.module.scss
@@ -14,6 +14,7 @@
   cursor: inherit;
   overflow-y: auto;
   overflow-x: auto;
+  flex-grow: 1;
 }
 
 .titleContainer {


### PR DESCRIPTION
The graph did not always take up all of the available space, as seen in the picture

![image](https://user-images.githubusercontent.com/80758782/162194165-1489beec-0946-4a1b-a4ab-277b100786c0.png)
