### PR TITLE
Disable MilestonesEditor features while loading

### DIFF
--- a/frontend/src/components/forms/SvgButton.module.scss
+++ b/frontend/src/components/forms/SvgButton.module.scss
@@ -1,17 +1,27 @@
 @import '../../shared.scss';
 
 .svgButtonIcon {
+  &:not(.disabled) {
+    &:hover path {
+      fill: var(--icon-hover-color, $COLOR_BLACK60);
+    }
+    cursor: pointer;
+  }
+
   path {
     fill: var(--icon--color, $COLOR_BLACK40);
     transition: 150ms ease-out;
   }
-  &:hover path {
-    fill: var(--icon-hover-color, $COLOR_BLACK60);
+  &.disabled path {
+    fill: var(--icon-disabled-color, $COLOR_BLACK40);
   }
-  cursor: pointer;
 }
 
 .closeButton {
   width: 24px !important;
   height: 24px !important;
+}
+
+a {
+  line-height: 1;
 }

--- a/frontend/src/components/forms/SvgButton.tsx
+++ b/frontend/src/components/forms/SvgButton.tsx
@@ -17,6 +17,7 @@ const classes = classNames.bind(css);
 
 type ButtonProps = {
   onClick?: (event: MouseEvent) => void;
+  disabled?: boolean;
 };
 
 type ExtraProps = {
@@ -36,16 +37,19 @@ function svgButton<E = {}>(
     ...defaults
   }: ExtraProps & { [K in keyof E]?: E[K] },
 ): SvgButton<Pick<E, Exclude<keyof E, keyof ExtraProps>>> {
-  return ({ href, ...props }) => {
+  return ({ href, disabled, onClick, ...props }) => {
     const icon = (
       <Icon
-        className={classes(css.svgButtonIcon, className)}
+        className={classes(css.svgButtonIcon, className, {
+          [css.disabled]: disabled,
+        })}
         style={{ '--icon--color': iconColor, '--icon-hover-color': hoverColor }}
+        onClick={disabled ? undefined : onClick}
         {...defaults}
         {...props}
       />
     );
-    return href ? <a href={href}>{icon}</a> : icon;
+    return disabled || !href ? icon : <a href={href}>{icon}</a>;
   };
 }
 

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -269,6 +269,7 @@ export const MilestonesEditor = () => {
             css.layoutRow,
             css.overflowYAuto,
             css.horizontalScroller,
+            { 'loading-cursor': disableDrag },
           )}
           ref={droppableProvided.innerRef}
         >
@@ -298,7 +299,6 @@ export const MilestonesEditor = () => {
                           <div
                             className={classes(css.instructions, {
                               [css.highlight]: snapshot.isDraggingOver,
-                              'loading-cursor': disableDrag,
                             })}
                             ref={provided.innerRef}
                             {...provided.droppableProps}
@@ -329,6 +329,7 @@ export const MilestonesEditor = () => {
                           id: version.id,
                           roadmapId: roadmapId!,
                         })}
+                        disabled={disableDrag}
                       />
                       <SettingsButton
                         onClick={editVersionClicked(version.id, version.name)}
@@ -336,6 +337,7 @@ export const MilestonesEditor = () => {
                           id: version.id,
                           name: version.name,
                         })}
+                        disabled={disableDrag}
                       />
                     </div>
                   </div>
@@ -346,12 +348,13 @@ export const MilestonesEditor = () => {
           <div className={classes(css.milestoneCol)}>
             <div
               className={classes(css.milestoneWrapper, css.addNewBtnWrapper)}
-              onClick={addVersion}
-              onKeyPress={addVersion}
-              role="button"
-              tabIndex={0}
             >
-              <button className={classes(css['button-large'])} type="submit">
+              <button
+                className={classes(css['button-large'])}
+                type="button"
+                onClick={addVersion}
+                disabled={disableDrag}
+              >
                 <Trans i18nKey="+ Add new milestone" />
               </button>
             </div>
@@ -401,6 +404,7 @@ export const MilestonesEditor = () => {
             listId={ROADMAP_LIST_ID}
             tasks={versionLists[ROADMAP_LIST_ID] || []}
             disableDragging={disableDrag}
+            className={classes({ 'loading-cursor': disableDrag })}
             showRatings
             showSearch
           />

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -280,6 +280,7 @@ form {
   }
   &:disabled {
     background: $COLOR_BLACK40;
+    cursor: inherit;
   }
 }
 


### PR DESCRIPTION
Any buttons that open a modal are disabled while versions are patched in MilestonesEditor.
- Loading cursor is applied to the whole milestone and expandable task list