### PR TITLE
Fix SortableTaskList drag bug on search

### DIFF
--- a/frontend/src/components/SortableTaskList.tsx
+++ b/frontend/src/components/SortableTaskList.tsx
@@ -92,7 +92,7 @@ export const SortableTaskList: FC<{
         mode="virtual"
         renderClone={(provided, _, rubric) => (
           <StaticTask
-            task={tasks[rubric.source.index]}
+            task={searched[rubric.source.index]}
             showRatings={!!showRatings}
             provided={provided}
           />


### PR DESCRIPTION
The dragged task was taken from the full list, not the searched one.