### PR TITLE
Change unstaged tasks -list to open automatically when taskmap canvas…

### DIFF
--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -57,6 +57,7 @@ export const TaskMapPage = () => {
     isLoading: isLoadingUsers,
   } = apiV2.useGetRoadmapUsersQuery(Number(roadmapId) ?? skipToken);
   const [isLoading, setIsLoading] = useState(false);
+  const [stagedReady, setStagedReady] = useState(false);
 
   useEffect(() => {
     if (relations === undefined) return;
@@ -83,7 +84,12 @@ export const TaskMapPage = () => {
         })),
       ),
     );
+    setStagedReady(true);
   }, [relations, tasks, stagedTasks]);
+
+  useEffect(() => {
+    if (stagedReady && !stagedTasks.length) setExpandUnstaged(true);
+  }, [stagedTasks, stagedReady]);
 
   const addSynergyRelations = (from: number, to: number[]) =>
     addSynergy({ roadmapId: roadmapId!, from, to }).unwrap();


### PR DESCRIPTION
This change opens unstaged tasks -list automatically when none of the tasks have been placed on the task map yet. Added it for improved usability since that's what you'd do first if the taskmap was empty