### PR TITLE
Fix stagedTasks visual bug in task map

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -105,7 +105,7 @@ export const TaskMap: FC<{
   }, [flowInstance, flowElements, mapPosition]);
 
   useEffect(() => {
-    if (!divRef || taskRelations.length === 0) return;
+    if (!divRef) return;
 
     const measuredRelations = taskRelations.map((relation, idx) => {
       // calculate taskgroup height


### PR DESCRIPTION
When trying to drag the last task from taskmap canvas to unstaged tasks -list, it was be displayed on both unstaged tasks and task map canvas as the tasks groups didn't update (TaskRelations.length === 0 in that case and the useEffect that creates the groups didn't run)

https://trello.com/c/PI0VbFax/613-kun-viimeinen-task-raahataan-kartasta-listaan-siirtyy-listaan-ja-n%C3%A4kyy-edelleen-kartassa