### PR TITLE
Planner read-mode

### DIFF
--- a/frontend/src/components/RoadmapSidebar.tsx
+++ b/frontend/src/components/RoadmapSidebar.tsx
@@ -13,7 +13,8 @@ import { ReactComponent as VisdomLogo } from '../icons/visdom_icon.svg';
 import css from './RoadmapSidebar.module.scss';
 import { userRoleSelector } from '../redux/user/selectors';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
-import { RoleType } from '../../../shared/types/customTypes';
+import { RoleType, Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
 import { apiV2, selectById } from '../api/api';
 
 const classes = classNames.bind(css);
@@ -21,6 +22,7 @@ const classes = classNames.bind(css);
 export const RoadmapSidebar: FC = () => {
   const { pathname } = useLocation();
   const role = useSelector(userRoleSelector, shallowEqual);
+  const hasReadVersionPermission = hasPermission(role, Permission.VersionRead);
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: roadmap, isFetching } = apiV2.useGetRoadmapsQuery(undefined, {
     ...selectById(roadmapId),
@@ -69,45 +71,45 @@ export const RoadmapSidebar: FC = () => {
           </Link>
         )}
         {role === RoleType.Admin && (
-          <>
-            <Link
-              to={url + paths.roadmapRelative.team}
-              className={classes(css.navButton, {
-                [css.selected]: pathname.startsWith(
-                  url + paths.roadmapRelative.team,
-                ),
-              })}
-            >
-              <DashboardIcon />
-              <Trans i18nKey="Team" />
-            </Link>
-            <Link
-              to={
-                url +
-                paths.roadmapRelative.planner +
-                paths.plannerRelative.editor
-              }
-              className={classes(css.navButton, {
-                [css.selected]: pathname.startsWith(
-                  url + paths.roadmapRelative.planner,
-                ),
-              })}
-            >
-              <TimelineIcon />
-              <Trans i18nKey="Plan" />
-            </Link>{' '}
-            <Link
-              to={url + paths.roadmapRelative.configure}
-              className={classes(css.navButton, css.settings, {
-                [css.selected]: pathname.startsWith(
-                  url + paths.roadmapRelative.configure,
-                ),
-              })}
-            >
-              <SettingsIcon />
-              <Trans i18nKey="Settings" />
-            </Link>
-          </>
+          <Link
+            to={url + paths.roadmapRelative.team}
+            className={classes(css.navButton, {
+              [css.selected]: pathname.startsWith(
+                url + paths.roadmapRelative.team,
+              ),
+            })}
+          >
+            <DashboardIcon />
+            <Trans i18nKey="Team" />
+          </Link>
+        )}
+        {hasReadVersionPermission && (
+          <Link
+            to={
+              url + paths.roadmapRelative.planner + paths.plannerRelative.editor
+            }
+            className={classes(css.navButton, {
+              [css.selected]: pathname.startsWith(
+                url + paths.roadmapRelative.planner,
+              ),
+            })}
+          >
+            <TimelineIcon />
+            <Trans i18nKey="Plan" />
+          </Link>
+        )}
+        {role === RoleType.Admin && (
+          <Link
+            to={url + paths.roadmapRelative.configure}
+            className={classes(css.navButton, css.settings, {
+              [css.selected]: pathname.startsWith(
+                url + paths.roadmapRelative.configure,
+              ),
+            })}
+          >
+            <SettingsIcon />
+            <Trans i18nKey="Settings" />
+          </Link>
         )}
       </>
     );

--- a/frontend/src/components/SortableTask.tsx
+++ b/frontend/src/components/SortableTask.tsx
@@ -13,35 +13,49 @@ export const StaticTask = forwardRef<
   {
     task: Task;
     showRatings: boolean;
+    hideDragIndicator?: boolean;
     provided?: DraggableProvided;
     style?: CSSProperties;
     className?: string;
   }
->(({ task, showRatings, provided, style, className }, ref) => (
-  <div
-    className={classes(css.taskDiv, className)}
-    ref={provided?.innerRef}
-    {...provided?.draggableProps}
-    {...provided?.dragHandleProps}
-    style={{ ...provided?.draggableProps.style, ...(style && { ...style }) }}
-  >
-    <div className={css.leftSideDiv} ref={ref}>
-      {task.name}
+>(
+  (
+    { task, showRatings, hideDragIndicator, provided, style, className },
+    ref,
+  ) => (
+    <div
+      className={classes(css.taskDiv, className)}
+      ref={provided?.innerRef}
+      {...provided?.draggableProps}
+      {...provided?.dragHandleProps}
+      style={{ ...provided?.draggableProps.style, ...(style && { ...style }) }}
+    >
+      <div className={css.leftSideDiv} ref={ref}>
+        {task.name}
+      </div>
+      <div className={css.rightSideDiv}>
+        {showRatings && <TaskRatingsText task={task} />}
+        {!hideDragIndicator && <DragIndicatorIcon fontSize="small" />}
+      </div>
     </div>
-    <div className={css.rightSideDiv}>
-      {showRatings && <TaskRatingsText task={task} />}
-      <DragIndicatorIcon fontSize="small" />
-    </div>
-  </div>
-));
+  ),
+);
 
 export const SortableTask: FC<{
   task: Task;
   index: number;
   disableDragging: boolean;
   showRatings: boolean;
+  hideDragIndicator?: boolean;
   style?: CSSProperties;
-}> = ({ task, index, disableDragging, showRatings, style }) => (
+}> = ({
+  task,
+  index,
+  disableDragging,
+  showRatings,
+  hideDragIndicator,
+  style,
+}) => (
   <Draggable
     key={task.id}
     draggableId={`${task.id}`}
@@ -54,6 +68,7 @@ export const SortableTask: FC<{
         showRatings={showRatings}
         provided={provided}
         style={style}
+        hideDragIndicator={hideDragIndicator}
       />
     )}
   </Draggable>

--- a/frontend/src/components/SortableTaskList.tsx
+++ b/frontend/src/components/SortableTaskList.tsx
@@ -30,6 +30,7 @@ export const SortableTaskList: FC<{
   disableDragging: boolean;
   isDropDisabled?: boolean;
   showRatings?: boolean;
+  hideDragIndicator?: boolean;
   showSearch?: boolean;
   className?: string;
 }> = ({
@@ -37,6 +38,7 @@ export const SortableTaskList: FC<{
   tasks,
   disableDragging,
   showRatings,
+  hideDragIndicator,
   showSearch,
   className,
   isDropDisabled,
@@ -79,10 +81,11 @@ export const SortableTaskList: FC<{
           index={index}
           disableDragging={disableDragging}
           showRatings={!!showRatings}
+          hideDragIndicator={hideDragIndicator}
         />
       );
     },
-    [disableDragging, showRatings],
+    [disableDragging, hideDragIndicator, showRatings],
   );
 
   return (

--- a/frontend/src/routers/PlannerPageRouter.tsx
+++ b/frontend/src/routers/PlannerPageRouter.tsx
@@ -1,10 +1,14 @@
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useSelector, shallowEqual } from 'react-redux';
+import { userRoleSelector } from '../redux/user/selectors';
 import { PageNavBar } from '../components/PageNavBar';
 import { MilestonesEditor } from '../pages/MilestonesEditor';
 import { PlannerWeightsPage } from '../pages/PlannerWeightsPage';
 import { RoadmapGraphPage } from '../pages/RoadmapGraphPage';
 import { TimeEstimationPage } from '../pages/TimeEstimationPage';
+import { Permission } from '../../../shared/types/customTypes';
+import { hasPermission } from '../../../shared/utils/permission';
 import { paths } from './paths';
 import '../shared.scss';
 
@@ -39,6 +43,11 @@ const routes = [
 export const PlannerPageRouter = () => {
   const { path } = useRouteMatch();
   const { t } = useTranslation();
+  const role = useSelector(userRoleSelector, shallowEqual);
+  const hasReadCustomerValuesPermission = hasPermission(
+    role,
+    Permission.RoadmapReadCustomerValues,
+  );
 
   const headers = [
     {
@@ -49,10 +58,14 @@ export const PlannerPageRouter = () => {
       url: '/editor',
       text: t('Milestones'),
     },
-    {
-      url: '/weights',
-      text: t('Client Weights'),
-    },
+    ...(hasReadCustomerValuesPermission
+      ? [
+          {
+            url: '/weights',
+            text: t('Client Weights'),
+          },
+        ]
+      : []),
     {
       url: '/timeestimation',
       text: t('Time Estimation'),

--- a/server/src/migrations/20220420080810_addPermissionVersionReadToBusinessRole.ts
+++ b/server/src/migrations/20220420080810_addPermissionVersionReadToBusinessRole.ts
@@ -1,0 +1,40 @@
+import { Permission } from '../../../shared/types/customTypes';
+import { Knex } from 'knex';
+import { Role } from '../api/roles/roles.model';
+import { Model } from 'objection';
+
+const oldBusinessRole =
+  Permission.TaskRead |
+  Permission.TaskCreate |
+  Permission.TaskEdit |
+  Permission.TaskDelete |
+  Permission.TaskRate |
+  Permission.TaskRatingEdit |
+  Permission.TaskValueRate |
+  Permission.CustomerRepresent |
+  Permission.RoadmapReadUsers |
+  Permission.EditRelations;
+
+const newBusinessRole = oldBusinessRole | Permission.VersionRead;
+
+export async function up(knex: Knex): Promise<void> {
+  Model.knex(knex);
+  await Role.query()
+    .where({
+      type: oldBusinessRole,
+    })
+    .update({
+      type: newBusinessRole,
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  Model.knex(knex);
+  await Role.query()
+    .where({
+      type: newBusinessRole,
+    })
+    .update({
+      type: oldBusinessRole,
+    });
+}

--- a/shared/types/customTypes.ts
+++ b/shared/types/customTypes.ts
@@ -71,5 +71,6 @@ export enum RoleType {
     Permission.TaskValueRate |
     Permission.CustomerRepresent |
     Permission.RoadmapReadUsers |
-    Permission.EditRelations,
+    Permission.EditRelations |
+    Permission.VersionRead,
 }


### PR DESCRIPTION
Planner is accessible in read mode to users with Permission.VersionRead.
- Developer or business -users do not have Permission.RoadmapReadCustomerValues, so in those cases the customer weights page is hidden and unweighted milestone values is used
- Add VersionRead-permission to business role