### PR TITLE
Cancel drag and drop when dropping task to unavailable groups

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -182,6 +182,7 @@ export const TaskMap: FC<{
                   dragHandle={dragHandle}
                   setGroupDraggable={setGroupDraggable}
                   isLoading={isLoading}
+                  nodeHeight={node.height}
                 />
               ),
             },

--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -57,6 +57,8 @@
 
   &.dropDisabled {
     cursor: not-allowed !important;
+    -webkit-transform: none !important;
+    transform: none !important;
   }
 
   &.loading {

--- a/frontend/src/components/TaskMapTaskGroup.module.scss
+++ b/frontend/src/components/TaskMapTaskGroup.module.scss
@@ -12,9 +12,12 @@
     cursor: all-scroll;
   }
 
+  // Needs to override dnd-default hover styles so !important is required
   &.unavailable {
+    max-height: var(--nodeHeight);
+    background-color: rgba($COLOR_CLOUD, 0.75) !important;
     filter: grayscale(100%) opacity(20%);
-    cursor: not-allowed;
+    cursor: not-allowed !important;
   }
 
   &.draggingSomething:not(.unavailable, .loading) {

--- a/frontend/src/components/TaskMapTaskGroup.tsx
+++ b/frontend/src/components/TaskMapTaskGroup.tsx
@@ -15,6 +15,7 @@ export const TaskGroup: FC<
     setSelectedTask: (task: Task | undefined) => void;
     allDependencies: { from: number; to: number }[];
     disableDrop?: boolean;
+    nodeHeight: number;
   } & Omit<TaskProps, 'taskId' | 'checked'>
 > = ({
   listId,
@@ -26,9 +27,10 @@ export const TaskGroup: FC<
   setGroupDraggable,
   draggingSomething,
   isLoading,
+  nodeHeight,
   ...rest
 }) => (
-  <Droppable isDropDisabled={disableDrop} droppableId={listId} type="TASKS">
+  <Droppable droppableId={listId} type="TASKS">
     {(provided, snapshot) => (
       <div
         className={classes(css.taskGroup, {
@@ -37,6 +39,9 @@ export const TaskGroup: FC<
           [css.unavailable]: disableDrop,
           [css.draggingSomething]: draggingSomething,
         })}
+        style={{
+          ['--nodeHeight' as any]: `${nodeHeight - 23}px`,
+        }}
         ref={provided.innerRef}
         {...provided.droppableProps}
       >

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -130,6 +130,7 @@ export const TaskMapPage = () => {
     const destinationId = Number(destination.droppableId);
     const sourceId = Number(source.droppableId);
 
+    if (dropUnavailable.has(destination.droppableId)) return;
     if (sourceId === -1) {
       // unstaged task added to existing group
       setStagedTasks((prev) => [...prev, draggedTaskId]);


### PR DESCRIPTION
Previously dropping a task on an unavailable group would count as dropping the task on the canvas (removing the task from the group). Now the drop gets cancelled instead and nothing happens.