### PR TITLE
Align TaskRatingsTexts to the left in TaskTable

### DIFF
--- a/frontend/src/components/TaskRatingsText.module.scss
+++ b/frontend/src/components/TaskRatingsText.module.scss
@@ -3,6 +3,8 @@
 .taskRatingRow {
   display: flex;
   gap: 11.75px;
+  flex: 1;
+  justify-content: flex-end;
 
   &.dragging {
     gap: calc(11.75px * #{$ZOOM});

--- a/frontend/src/components/TaskTable.tsx
+++ b/frontend/src/components/TaskTable.tsx
@@ -32,9 +32,7 @@ export const TaskRow: FC<{
         <DoneAllIcon className={classes(css.doneIcon)} />
       )}
       <div className={classes(css.taskName)}>{task.name}</div>
-      <div className={classes(css.taskRatingTexts)}>
-        <TaskRatingsText task={task} largeIcons={largeIcons} />
-      </div>
+      <TaskRatingsText task={task} largeIcons={largeIcons} />
     </div>
   );
 };


### PR DESCRIPTION
The texts were sometimes out of align
![image](https://user-images.githubusercontent.com/80758782/167620180-e93569f3-2035-4718-8462-5e1bd81c2080.png)
