### PR TITLE
Planner relation modal in drawer

### DIFF
--- a/frontend/src/components/SortableTask.tsx
+++ b/frontend/src/components/SortableTask.tsx
@@ -10,7 +10,7 @@ import {
   TaskRelationTableType,
   RelationAnnotation,
 } from '../utils/TaskRelationUtils';
-import { ModalTypes, modalLink } from './modals/types';
+import { ModalTypes, modalDrawerLink } from './modals/types';
 import { TaskRatingsText } from './TaskRatingsText';
 import { InfoTooltip } from './InfoTooltip';
 import css from './SortableTask.module.scss';
@@ -37,7 +37,7 @@ const UnmetDependencyTooltip = (payload: {
       <p>Unmet dependency order</p>
       <Link
         className="green"
-        to={modalLink(ModalTypes.RELATIONS_MODAL, payload)}
+        to={modalDrawerLink(ModalTypes.RELATIONS_MODAL, payload)}
       >
         Show relations
       </Link>

--- a/frontend/src/components/TaskTable.module.scss
+++ b/frontend/src/components/TaskTable.module.scss
@@ -97,3 +97,13 @@
   margin-left: 26px;
   text-align: left;
 }
+
+.relationList {
+  overflow-y: auto;
+  width: 105%;
+}
+
+.relationRow {
+  @extend .layout-row;
+  align-items: center;
+}

--- a/frontend/src/components/TaskTable.module.scss
+++ b/frontend/src/components/TaskTable.module.scss
@@ -1,3 +1,4 @@
+@import '../shared.scss';
 @import './TaskMapTask.module.scss';
 
 // Bottom and top left radius for clean looking hover
@@ -70,6 +71,8 @@
 }
 
 .namesContainer {
+  @extend .taskNameContainer;
+  max-height: unset;
   @extend .layout-column;
   gap: 5px;
   & > div {

--- a/frontend/src/components/TaskTable.tsx
+++ b/frontend/src/components/TaskTable.tsx
@@ -109,7 +109,11 @@ export const TaskRelationTable: FC<{
     <div className={classes(css.relationList)} style={{ maxHeight: height }}>
       {tasks.map((t) => (
         <div key={t.id} className={classes(css.relationRow)}>
-          <TaskRow task={t} {...taskProps} />
+          <TaskRow
+            task={t}
+            {...taskProps}
+            style={{ height: 'unset', ...taskProps?.style }}
+          />
           <Action task={t} />
         </div>
       ))}

--- a/frontend/src/components/modals/RelationsModal.module.scss
+++ b/frontend/src/components/modals/RelationsModal.module.scss
@@ -49,20 +49,10 @@
   color: $COLOR_BLACK60;
 }
 
-.relationList {
-  overflow-y: auto;
-  width: 105%;
-}
-
 .relationAlert {
   width: 20px;
   svg {
     width: 15px;
     height: 100%;
   }
-}
-
-.relationRow {
-  @extend .layout-row;
-  align-items: center;
 }

--- a/frontend/src/components/modals/RelationsModal.tsx
+++ b/frontend/src/components/modals/RelationsModal.tsx
@@ -9,8 +9,6 @@ import ClockIcon from '@mui/icons-material/Schedule';
 import CheckIcon from '@mui/icons-material/Check';
 import { ModalTypes, Modal } from './types';
 import { ModalContent } from './modalparts/ModalContent';
-import { ModalFooter } from './modalparts/ModalFooter';
-import { ModalFooterButtonDiv } from './modalparts/ModalFooterButtonDiv';
 import { ModalHeader } from './modalparts/ModalHeader';
 import { Info } from './modalparts/Info';
 import { Checkbox } from '../forms/Checkbox';
@@ -238,17 +236,6 @@ export const RelationsModal: Modal<ModalTypes.RELATIONS_MODAL> = ({
           </p>
         </div>
       </ModalContent>
-      <ModalFooter>
-        <ModalFooterButtonDiv>
-          <button
-            className="button-large"
-            type="button"
-            onClick={() => closeModal()}
-          >
-            <Trans i18nKey="Ok" />
-          </button>
-        </ModalFooterButtonDiv>
-      </ModalFooter>
     </div>
   );
 };

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -10,6 +10,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import classNames from 'classnames';
+import Drawer from '@mui/material/Drawer';
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import DoneAll from '@mui/icons-material/DoneAll';
 import { Link } from 'react-router-dom';
@@ -23,7 +24,8 @@ import { ExpandableColumn } from '../components/ExpandableColumn';
 import { MilestoneRatingsSummary } from '../components/MilestoneRatingsSummary';
 import { StoreDispatchType } from '../redux';
 import { modalsActions } from '../redux/modals';
-import { ModalTypes, modalLink } from '../components/modals/types';
+import { ModalTypes, modalLink, useModal } from '../components/modals/types';
+import { RelationsModal } from '../components/modals/RelationsModal';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
 import { Task, Version, TaskRelation } from '../redux/roadmaps/types';
 import {
@@ -108,6 +110,8 @@ const copyVersionLists = (originalLists: VersionListsObject) => {
 const ROADMAP_LIST_ID = '-1';
 
 export const MilestonesEditor = () => {
+  const drawer = useModal('openDrawer', ModalTypes.RELATIONS_MODAL);
+
   const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: tasks } = apiV2.useGetTasksQuery(roadmapId ?? skipToken);
@@ -663,6 +667,22 @@ export const MilestonesEditor = () => {
           {renderTopBar()}
           <div className={classes(css.layoutRow, css.overflowYAuto)}>
             {versionLists && renderMilestones()}
+            <Drawer
+              anchor="right"
+              variant="persistent"
+              open={!!drawer.payload}
+              BackdropProps={{ invisible: true }}
+              className={classes(css.drawer)}
+            >
+              {drawer.payload && (
+                <div style={{ marginTop: 20 }}>
+                  <RelationsModal
+                    closeModal={drawer.close}
+                    {...drawer.payload.modalProps}
+                  />
+                </div>
+              )}
+            </Drawer>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/RoadmapGraphPage.module.scss
+++ b/frontend/src/pages/RoadmapGraphPage.module.scss
@@ -6,10 +6,6 @@
   overflow: hidden;
 }
 
-.drawer:global(.MuiDrawer-root .MuiDrawer-paper) {
-  position: relative;
-}
-
 .plannerPagecontainer {
   cursor: inherit;
   overflow-y: auto;

--- a/frontend/src/routers/MainRouter.tsx
+++ b/frontend/src/routers/MainRouter.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
-import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../redux/types';
 import { UserInfo } from '../redux/user/types';
 import { userInfoSelector } from '../redux/user/selectors';
 import { StoreDispatchType } from '../redux';
 import { modalsActions } from '../redux/modals';
-import { ModalTypes } from '../components/modals/types';
+import { useModal } from '../components/modals/types';
 import { NavLayout } from '../components/NavLayout';
 import { HomePage } from '../pages/HomePage';
 import { LandingPage } from '../pages/LandingPage';
@@ -114,36 +114,13 @@ const routes = [
 ];
 
 export const MainRouter = () => {
-  const query = new URLSearchParams(useLocation().search);
+  const { payload } = useModal('openModal');
   const dispatch = useDispatch<StoreDispatchType>();
-
-  // Parse query params
-  let queryModal = query.get('openModal');
-  if (
-    !queryModal ||
-    !Object.values(ModalTypes).includes(queryModal as ModalTypes)
-  ) {
-    queryModal = null;
-  }
-  let queryProps = query.get('modalProps');
-  try {
-    queryProps = JSON.parse(queryProps!);
-  } catch (e) {
-    queryProps = null;
-  }
 
   useEffect(() => {
     // Open modals for corresponding query params
-    if (!queryModal) return;
-    if (!queryProps) return;
-
-    dispatch(
-      modalsActions.showModal({
-        modalType: queryModal as any,
-        modalProps: queryProps as any,
-      }),
-    );
-  }, [queryModal, queryProps, dispatch]);
+    if (payload) dispatch(modalsActions.showModal(payload));
+  }, [payload, dispatch]);
 
   return (
     <Switch>

--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -58,6 +58,10 @@
   border-radius: 10px 0px 0px 10px;
 }
 
+.drawer:global(.MuiDrawer-root .MuiDrawer-paper) {
+  position: relative;
+}
+
 label {
   @extend .typography-pre-title;
   color: $COLOR_AZURE;


### PR DESCRIPTION
Showing the relations in a drawer in the side instead of modal that would block the rest of the page.

I'm maybe abusing the modal link system a bit, but it works.
There is an extra horizontal scroll bar when the drawer is closed for some reason, don't yet know why.