### PR TITLE
Fix crash on missing tasks in milestone editor

### DIFF
--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -149,11 +149,11 @@ export const MilestonesEditor = () => {
   }, [isLoading, versionLists]);
 
   useEffect(() => {
-    if (!roadmapsVersions) return;
+    if (!roadmapsVersions || !tasks) return;
 
     const newVersionLists: { [k: string]: Task[] } = {};
     const ratedTasks = new Map(
-      tasks?.filter(hasRatingsOnEachDimension).map((task) => [task.id, task]),
+      tasks.filter(hasRatingsOnEachDimension).map((task) => [task.id, task]),
     );
     const tasksById = new Map(ratedTasks);
 
@@ -173,10 +173,14 @@ export const MilestonesEditor = () => {
       ids.map((key) => newVersionLists[key].map(({ id }) => id)),
       relations ?? [],
     ).forEach((check, index) => {
-      result[ids[index]] = check.map(({ id, ...rest }) => ({
-        ...tasksById.get(id)!,
-        ...rest,
-      }));
+      result[ids[index]] = check.flatMap(({ id, ...rest }) => {
+        const task = tasksById.get(id);
+        if (!task) {
+          console.error(`Failed to find task by id ${id}`);
+          return [];
+        }
+        return [{ ...task, ...rest }];
+      });
     });
     setVersionLists(result);
   }, [customers, tasks, roadmapsVersions, isError, relations]);


### PR DESCRIPTION
The `tasks` could be `undefined` in some circumstances, which lead to
silent failure in lookup from `tasksById`, and a crash later in the
page.

Repro of the error:
- navigate to `/roadmap/1/planner/graph`
- refresh the page
- select the `milestones` tab
- page crashes