### PR TITLE
Task map - remove remaining ratings

### DIFF
--- a/frontend/src/components/SortableTaskList.tsx
+++ b/frontend/src/components/SortableTaskList.tsx
@@ -75,6 +75,7 @@ export const SortableTaskList: FC<{
           <SearchField
             placeholder={t('Search for type', { searchType: 'tasks' })}
             onChange={setSearch}
+            searchThreshold={0}
           />
         </div>
       )}

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -239,7 +239,6 @@ export const TaskMapPage = () => {
                     type === TaskRelationType.Dependency,
                 )
               }
-              showRatings
               showSearch
             />
           </ExpandableColumn>


### PR DESCRIPTION
Not sure if this was intentionally left out from #406, but I now removed the ratings from the unstaged list too.

Also removed the search threshold from the task list, as that is fast enough.