### PR TITLE
Add edition for roadmap name and description

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -238,6 +238,14 @@ export const apiV2 = createApi({
         method: 'delete',
       }),
     }),
+    patchRoadmap: build.mutation<Roadmap, RoadmapRequest>({
+      invalidatesTags: (result) => (result ? ['Roadmaps'] : []),
+      query: ({ id, name, description }) => ({
+        url: `/roadmaps/${id}`,
+        method: 'patch',
+        data: { name, description },
+      }),
+    }),
     addRoadmap: build.mutation<Roadmap, RoadmapCreation>({
       invalidatesTags: ['Roadmaps'],
       query: (roadmap) => ({ url: '/roadmaps', method: 'post', data: roadmap }),

--- a/frontend/src/components/Overview.tsx
+++ b/frontend/src/components/Overview.tsx
@@ -29,7 +29,7 @@ interface OverviewData {
 }
 
 interface OverviewContentProps {
-  metrics: MetricsProps[];
+  metrics?: MetricsProps[];
   data: OverviewData[][];
 }
 
@@ -49,13 +49,15 @@ export const OverviewContent: FC<OverviewContentProps> = ({
   data,
 }) => (
   <div className={classes(css.content)}>
-    <div className={classes(css.metrics)}>
-      {metrics.map(({ label, value, children }) => (
-        <MetricsSummary key={label} label={label} value={value}>
-          {children}
-        </MetricsSummary>
-      ))}
-    </div>
+    {metrics && (
+      <div className={classes(css.metrics)}>
+        {metrics.map(({ label, value, children }) => (
+          <MetricsSummary key={label} label={label} value={value}>
+            {children}
+          </MetricsSummary>
+        ))}
+      </div>
+    )}
     <div className={classes(css.data)}>
       {data.map((column, idx) => (
         // eslint-disable-next-line react/no-array-index-key

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -11,6 +11,7 @@ export const english = {
     'Add new milestone': 'Add new milestone',
     'Add new': 'Add new',
     'Task name': 'Task name',
+    'Roadmap name': 'Roadmap name',
     Description: 'Description',
     Tasks: 'Tasks',
     Task: 'Task',

--- a/frontend/src/pages/ConfigurationPage.module.scss
+++ b/frontend/src/pages/ConfigurationPage.module.scss
@@ -3,6 +3,7 @@
 .configurationPage {
   @extend .layoutCol;
   margin-left: 27px;
+  margin-top: 20px;
   gap: 20px;
 }
 

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -1,4 +1,4 @@
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import classNames from 'classnames';
@@ -10,8 +10,10 @@ import { UserInfo } from '../redux/user/types';
 import { RoleType } from '../../../shared/types/customTypes';
 import { requireVerifiedEmail } from '../utils/requirelogin';
 import { getType } from '../utils/UserUtils';
-import { apiV2 } from '../api/api';
+import { apiV2, selectById } from '../api/api';
 import { IntegrationConfig } from '../components/IntegrationConfiguration';
+import { OverviewContent } from '../components/Overview';
+import { EditableTextWithButtons } from '../components/EditableText';
 
 import css from './ConfigurationPage.module.scss';
 
@@ -22,13 +24,29 @@ const RoadmapConfigurationPageComponent = ({
 }: {
   userInfo: UserInfo;
 }) => {
+  const { t } = useTranslation();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const dispatch = useDispatch<StoreDispatchType>();
   const userType = getType(userInfo, roadmapId);
-
+  const [patchRoadmap] = apiV2.usePatchRoadmapMutation();
   const { data: integrations } = apiV2.useGetIntegrationsQuery(
     roadmapId ?? skipToken,
   );
+  const { data: roadmap } = apiV2.useGetRoadmapsQuery(undefined, {
+    skip: !roadmapId,
+    ...selectById(roadmapId),
+  });
+
+  const handleEditConfirm = async (newValue: string, fieldId: string) => {
+    try {
+      await patchRoadmap({
+        id: roadmapId!,
+        [fieldId]: newValue,
+      }).unwrap();
+    } catch (err: any) {
+      return err.data?.message ?? 'something went wrong';
+    }
+  };
 
   const openDeleteRoadmapModal = (e: any) => {
     e.preventDefault();
@@ -42,9 +60,44 @@ const RoadmapConfigurationPageComponent = ({
   };
 
   if (userType !== RoleType.Admin) return null;
+  if (!roadmap) return null;
+
+  const overviewData = [
+    [
+      {
+        label: t('Roadmap name'),
+        value: roadmap.name,
+        format: 'bold',
+        EditComponent: (
+          <EditableTextWithButtons
+            onOk={handleEditConfirm}
+            value={roadmap.name}
+            fieldId="name"
+            format="bold"
+          />
+        ),
+      },
+    ],
+    [
+      {
+        label: t('Description'),
+        value: roadmap.description,
+        format: 'multiline',
+        EditComponent: (
+          <EditableTextWithButtons
+            onOk={handleEditConfirm}
+            value={roadmap.description}
+            fieldId="description"
+            format="multiline"
+          />
+        ),
+      },
+    ],
+  ];
 
   return (
     <div className={classes(css.configurationPage)}>
+      <OverviewContent data={overviewData} />
       {roadmapId &&
         integrations &&
         Object.keys(integrations).map((name) => (


### PR DESCRIPTION
Takes advantage of overviewContent. Not necessarily in align with the look of the settings-page, but gets the job done.