### PR TITLE
Add sanity check and better typing for paths

### DIFF
--- a/frontend/src/routers/paths.ts
+++ b/frontend/src/routers/paths.ts
@@ -1,7 +1,21 @@
 const uuidPattern =
   '[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}';
 
-export const paths = {
+type Paths<T> = T extends `/${string}`
+  ? T extends `/${string}/`
+    ? never
+    : T
+  : T extends { [K: string]: unknown }
+  ? { [K in keyof T]: Paths<T[K]> }
+  : never;
+
+// Make sure that each specified path segment
+// - starts with a '/'
+// - does not have a trailing '/' after the last path component
+// And provides a literal type for the segments.
+const checkPaths = <T>(x: Paths<T>) => x;
+
+export const paths = checkPaths({
   home: '/',
   userInfo: '/user',
   loginPage: '/login',
@@ -22,7 +36,6 @@ export const paths = {
     clients: '/clients',
     clientOverview: '/clients/:clientId([0-9]+)',
     team: '/team',
-    taskList: '/tasks',
     tasks: '/tasks',
     planner: '/planner',
     configure: '/configure',
@@ -38,4 +51,4 @@ export const paths = {
     taskmap: '/taskmap',
     taskOverview: '/:taskId([0-9]+)',
   },
-};
+});


### PR DESCRIPTION
It hasn't been once or twice when I've had to peek into the definition
to see if I should add a separator or not.

This enforces a consistent format for the defined segments:
- segment must start with the separator
- segment must not end with the separator, unless it consist only of the
  separator

The format as a regular expression:
/|/.*[^/]

This also provides literal types for the segments, making it easier to
look up the value when necessary.

Also removed one unused duplicate definition.