### PR TITLE
Add default sort prop to RatingTable

### DIFF
--- a/frontend/src/components/RatingTable.tsx
+++ b/frontend/src/components/RatingTable.tsx
@@ -51,6 +51,7 @@ export type RatingRow = FC<{
 interface RatingTableDef {
   type: TaskRatingDimension;
   Row: RatingRow;
+  defaultSort: TaskRatingSortingTypes;
 }
 
 type RatingTableProps = {
@@ -65,6 +66,7 @@ type RatingTableProps = {
 export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
   Row,
   type,
+  defaultSort,
 }) => ({ task, ratings, avg, height = 800 }) => {
   const dispatch = useDispatch<StoreDispatchType>();
   const userInfo = useSelector<RootState, UserInfo | undefined>(
@@ -74,10 +76,7 @@ export const ratingTable: (def: RatingTableDef) => FC<RatingTableProps> = ({
   const listRef = useRef<VariableSizeList<any> | null>(null);
   const [divRef, setDivRef] = useState<HTMLDivElement | null>(null);
   const { t } = useTranslation();
-  const [sort, sorting] = useSorting(
-    taskRatingsSort,
-    TaskRatingSortingTypes.SORT_FOR_CUSTOMER,
-  );
+  const [sort, sorting] = useSorting(taskRatingsSort, defaultSort);
   const [scrollBarWidth, setScrollBarWidth] = useState(0);
   const [rowHeights, setRowHeights] = useState<number[]>([]);
   const [listHeight, setListHeight] = useState(0);

--- a/frontend/src/components/RatingTableComplexity.tsx
+++ b/frontend/src/components/RatingTableComplexity.tsx
@@ -14,6 +14,7 @@ import css from './RatingTable.module.scss';
 import { apiV2, selectById } from '../api/api';
 import { userRoleSelector } from '../redux/user/selectors';
 import { hasPermission } from '../../../shared/utils/permission';
+import { TaskRatingSortingTypes } from '../utils/SortRatingsUtils';
 
 const classes = classNames.bind(css);
 
@@ -70,4 +71,5 @@ const TableComplexityRatingRow: RatingRow = ({
 export const RatingTableComplexity = ratingTable({
   type: TaskRatingDimension.Complexity,
   Row: TableComplexityRatingRow,
+  defaultSort: TaskRatingSortingTypes.SORT_CREATED_BY_USER,
 });

--- a/frontend/src/components/RatingTableValue.tsx
+++ b/frontend/src/components/RatingTableValue.tsx
@@ -15,6 +15,7 @@ import css from './RatingTable.module.scss';
 import { apiV2, selectById } from '../api/api';
 import { userRoleSelector } from '../redux/user/selectors';
 import { hasPermission } from '../../../shared/utils/permission';
+import { TaskRatingSortingTypes } from '../utils/SortRatingsUtils';
 
 const classes = classNames.bind(css);
 
@@ -83,4 +84,5 @@ const TableValueRatingRow: RatingRow = ({
 export const RatingTableValue = ratingTable({
   type: TaskRatingDimension.BusinessValue,
   Row: TableValueRatingRow,
+  defaultSort: TaskRatingSortingTypes.SORT_FOR_CUSTOMER,
 });


### PR DESCRIPTION
Default sorting for complexity-table is creator instead of the customer.
Only solves part of the problem: customer is still selectable as sorting, which is useless for complexity-table. I made [a card about that](https://trello.com/c/CopQGUnQ/696-taskoverview-poista-customer-sort-vaihtoehto-complexity-rating-tablesta).