### PR TITLE
Correct TaskMap portal creation

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -216,6 +216,7 @@ export const TaskMap: FC<{
       style={{
         ['--zoom' as any]: mapPosition?.zoom || 1,
       }}
+      id="taskmap"
     >
       <ReactFlow
         connectionLineComponent={ConnectionLine}

--- a/frontend/src/components/TaskMapTask.module.scss
+++ b/frontend/src/components/TaskMapTask.module.scss
@@ -34,8 +34,7 @@
     width: 100%;
 
     &.dragging {
-      width: calc(210px * #{$ZOOM});
-      height: calc(52px * #{$ZOOM});
+      max-height: calc(40px * #{$ZOOM});
     }
   }
 
@@ -54,7 +53,7 @@
     }
 
     .doneIcon {
-      margin-right: calc(5px * #{$ZOOM});
+      margin-right: calc(10px * #{$ZOOM});
       width: calc(1em * #{$ZOOM});
       height: calc(1em * #{$ZOOM});
     }

--- a/frontend/src/pages/TaskMapPage.tsx
+++ b/frontend/src/pages/TaskMapPage.tsx
@@ -203,7 +203,6 @@ export const TaskMapPage = () => {
 
   return (
     <div
-      id="taskmap"
       className={classes(css.taskmap, css.grow, { [css.loading]: isLoading })}
     >
       <DragDropContext


### PR DESCRIPTION
The portal containing dragged tasks was attached to TaskMapPage, where zoom level was not in scope. This lead to broken dragging styles.

After the correction, most dragging styles are fixed. However, Handle's border-width remains broken for unknown reasons.