### PR TITLE
Add more elaborate settings-page styles

### DIFF
--- a/frontend/src/components/IntegrationConfiguration.module.scss
+++ b/frontend/src/components/IntegrationConfiguration.module.scss
@@ -14,6 +14,12 @@
   text-align: left;
 }
 
+.columnHeader {
+  @extend .typography-h3;
+  text-align: left;
+  padding-top: 16px;
+}
+
 .configHeader {
   @extend .layout-row;
   align-items: center;

--- a/frontend/src/components/IntegrationConfiguration.module.scss
+++ b/frontend/src/components/IntegrationConfiguration.module.scss
@@ -18,7 +18,7 @@
   @extend .layout-row;
   align-items: center;
   gap: 10px;
-  margin: 16px;
+  margin: 16px 10px;
   margin-bottom: 10px;
 
   text-align: left;

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -330,6 +330,8 @@ export const english = {
       'Do you want to log in again with different email to join?',
     'Yes, log in again': 'Yes, log in again',
     Oops: 'Oops...',
+    'Delete project note':
+      'Note: Do not delete the project if you only want to leave it.',
     'Page not found description 1/2':
       'It seems we can’t find the page you’re looking for.',
     'Page not found description 2/2':

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -46,6 +46,8 @@ export const english = {
     'Set as default project': 'Set as default project',
     'Delete project ellipsis': 'Delete project...',
     'Delete project': 'Delete project',
+    Project: 'Project',
+    Integrations: 'Integrations',
     'task list': 'task list',
     Plan: 'Plan',
     Previous: 'Previous',

--- a/frontend/src/pages/ConfigurationPage.module.scss
+++ b/frontend/src/pages/ConfigurationPage.module.scss
@@ -2,21 +2,21 @@
 
 .settingsPage {
   @extend .layoutCol;
-  margin: 25px 20px;
-  gap: 60px;
+  margin: 10px 20px;
+  gap: 80px;
 }
 
 .setting {
   @extend .layout-column;
   align-items: flex-start;
 
-  &:last-child {
-    margin-top: auto;
-  }
-
   h2 {
     text-align: left;
     margin-bottom: 20px;
+  }
+  h3 {
+    text-align: left;
+    margin-bottom: 0;
   }
 }
 
@@ -24,4 +24,20 @@
   @extend .layout-row;
   flex-wrap: wrap;
   gap: 70px;
+}
+
+.projectInfo {
+  @extend .layout-column;
+  width: 100%;
+  gap: 20px;
+
+  .deleteContent {
+    @extend .layout-row;
+    gap: 100px;
+    align-items: flex-end;
+
+    button {
+      width: max-content;
+    }
+  }
 }

--- a/frontend/src/pages/ConfigurationPage.module.scss
+++ b/frontend/src/pages/ConfigurationPage.module.scss
@@ -1,14 +1,27 @@
 @import '../shared.scss';
 
-.configurationPage {
+.settingsPage {
   @extend .layoutCol;
-  margin-left: 27px;
-  margin-top: 20px;
-  gap: 20px;
+  margin: 25px 20px;
+  gap: 60px;
 }
 
-.columnHeader {
-  @extend .typography-h3;
-  text-align: left;
-  padding-top: 16px;
+.setting {
+  @extend .layout-column;
+  align-items: flex-start;
+
+  &:last-child {
+    margin-top: auto;
+  }
+
+  h2 {
+    text-align: left;
+    margin-bottom: 20px;
+  }
+}
+
+.integrations {
+  @extend .layout-row;
+  flex-wrap: wrap;
+  gap: 70px;
 }

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -96,7 +96,32 @@ const RoadmapConfigurationPageComponent = ({
   ];
 
   const settings = [
-    { title: t('Project'), content: <OverviewContent data={overviewData} /> },
+    {
+      title: t('Project'),
+      content: (
+        <div className={classes(css.projectInfo)}>
+          <OverviewContent data={overviewData} />
+          <div>
+            <h3>
+              <Trans i18nKey="Delete project" />
+            </h3>
+            <div className={classes(css.deleteContent)}>
+              <Trans i18nKey="Delete project note" />
+              <button
+                className={classes(
+                  css['button-small-filled'],
+                  css.deleteButton,
+                )}
+                type="submit"
+                onClick={openDeleteRoadmapModal}
+              >
+                <Trans i18nKey="Delete project" />
+              </button>
+            </div>
+          </div>
+        </div>
+      ),
+    },
     {
       title: t('Integrations'),
       content: roadmapId && integrations && (
@@ -105,18 +130,6 @@ const RoadmapConfigurationPageComponent = ({
             <IntegrationConfig roadmapId={roadmapId} name={name} key={name} />
           ))}
         </div>
-      ),
-    },
-    {
-      title: t('Delete project'),
-      content: (
-        <button
-          className={classes(css['button-small-filled'], css.deleteButton)}
-          type="submit"
-          onClick={openDeleteRoadmapModal}
-        >
-          <Trans i18nKey="Delete project" />
-        </button>
       ),
     },
   ];

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -65,7 +65,7 @@ const RoadmapConfigurationPageComponent = ({
   const overviewData = [
     [
       {
-        label: t('Roadmap name'),
+        label: t('Name'),
         value: roadmap.name,
         format: 'bold',
         EditComponent: (
@@ -95,29 +95,40 @@ const RoadmapConfigurationPageComponent = ({
     ],
   ];
 
+  const settings = [
+    { title: t('Project'), content: <OverviewContent data={overviewData} /> },
+    {
+      title: t('Integrations'),
+      content: roadmapId && integrations && (
+        <div className={classes(css.integrations)}>
+          {Object.keys(integrations).map((name) => (
+            <IntegrationConfig roadmapId={roadmapId} name={name} key={name} />
+          ))}
+        </div>
+      ),
+    },
+    {
+      title: t('Delete project'),
+      content: (
+        <button
+          className={classes(css['button-small-filled'], css.deleteButton)}
+          type="submit"
+          onClick={openDeleteRoadmapModal}
+        >
+          <Trans i18nKey="Delete project" />
+        </button>
+      ),
+    },
+  ];
+
   return (
-    <div className={classes(css.configurationPage)}>
-      <OverviewContent data={overviewData} />
-      {roadmapId &&
-        integrations &&
-        Object.keys(integrations).map((name) => (
-          <div key={name}>
-            <IntegrationConfig roadmapId={roadmapId} name={name} />
-          </div>
-        ))}
-      <div className={classes(css.layoutRow)}>
-        <span className={classes(css.columnHeader)}>
-          <Trans i18nKey="Delete roadmap" />
-          <br />
-          <button
-            className={classes(css['button-small-filled'], css.deleteButton)}
-            type="submit"
-            onClick={openDeleteRoadmapModal}
-          >
-            <Trans i18nKey="Delete roadmap" />
-          </button>
-        </span>
-      </div>
+    <div className={classes(css.settingsPage)}>
+      {settings.map(({ title, content }) => (
+        <div className={classes(css.setting)} key={title}>
+          <h2>{title}</h2>
+          {content}
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
https://trello.com/c/34SGwwTr/694-setting-sivun-yleisilme-siistimm%C3%A4ksi

Since a strict design was missing, the I tried a layout reminiscent of user info or overview pages. Patric also experimented with side-by-side integrations, which seems nice

Not sure if the `margin-top: auto;` looks best with the delete button: opinions are welcome.


As a note, there is [a separate card for configuration styles](https://trello.com/c/Up1B94vI/698-setting-configuration-tyylit-figman-mukaiseksi).