### PR TITLE
Add tooltip to the taskmap position reset -button

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -285,10 +285,12 @@ export const TaskMap: FC<{
               className={classes(css.info, css.tooltipIcon, css.infoIcon)}
             />
           </InfoTooltip>
-          <RestartAltIcon
-            className={classes(css.restart)}
-            onClick={resetCanvas}
-          />
+          <InfoTooltip title={t('Reset taskgroup positions')}>
+            <RestartAltIcon
+              className={classes(css.restart)}
+              onClick={resetCanvas}
+            />
+          </InfoTooltip>
         </Controls>
       </ReactFlow>
     </div>

--- a/frontend/src/i18/english.ts
+++ b/frontend/src/i18/english.ts
@@ -419,5 +419,6 @@ export const english = {
     'Client shares score': 'Client shares score',
     Poor: 'Poor',
     Great: 'Great',
+    'Reset taskgroup positions': 'Reset taskgroup positions',
   },
 };


### PR DESCRIPTION
Added a tooltip on the task group reset button on the task map so it's a bit more clear to the user