### PR TITLE
Add navigation from task overview to planner

### DIFF
--- a/frontend/src/components/modals/RelationsModal.tsx
+++ b/frontend/src/components/modals/RelationsModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
@@ -130,6 +130,7 @@ export const RelationsModal: Modal<ModalTypes.RELATIONS_MODAL> = ({
   closeModal,
 }) => {
   const { t } = useTranslation();
+  const { pathname, search } = useLocation();
   const dispatch = useDispatch<StoreDispatchType>();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: task } = apiV2.useGetTasksQuery(
@@ -178,7 +179,11 @@ export const RelationsModal: Modal<ModalTypes.RELATIONS_MODAL> = ({
                     className="green"
                     to={`${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.tasks}/${task.id}`}
                     onClick={() => {
-                      dispatch(roadmapsActions.setFromMilestonesEditor());
+                      dispatch(
+                        roadmapsActions.setFromMilestonesEditor(
+                          `${pathname}${search}`,
+                        ),
+                      );
                       closeModal();
                     }}
                   >

--- a/frontend/src/components/modals/RelationsModal.tsx
+++ b/frontend/src/components/modals/RelationsModal.tsx
@@ -2,7 +2,7 @@ import { FC, useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { ModalTypes, Modal } from './types';
 import { ModalContent } from './modalparts/ModalContent';
@@ -12,6 +12,8 @@ import { Checkbox } from '../forms/Checkbox';
 import { RelationIcon } from '../RelationIcon';
 import { Task, TaskRelation } from '../../redux/roadmaps/types';
 import { chosenRoadmapIdSelector } from '../../redux/roadmaps/selectors';
+import { StoreDispatchType } from '../../redux';
+import { roadmapsActions } from '../../redux/roadmaps';
 import { ReactComponent as AlertIcon } from '../../icons/alert-exclamation-mark.svg';
 import { InfoTooltip } from '../InfoTooltip';
 import { LoadingSpinner } from '../LoadingSpinner';
@@ -128,6 +130,7 @@ export const RelationsModal: Modal<ModalTypes.RELATIONS_MODAL> = ({
   closeModal,
 }) => {
   const { t } = useTranslation();
+  const dispatch = useDispatch<StoreDispatchType>();
   const roadmapId = useSelector(chosenRoadmapIdSelector);
   const { data: task } = apiV2.useGetTasksQuery(
     roadmapId ?? skipToken,
@@ -175,6 +178,7 @@ export const RelationsModal: Modal<ModalTypes.RELATIONS_MODAL> = ({
                     className="green"
                     to={`${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.tasks}/${task.id}`}
                     onClick={() => {
+                      dispatch(roadmapsActions.setFromMilestonesEditor());
                       closeModal();
                     }}
                   >

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -177,7 +177,10 @@ const TaskOverview: FC<{
   const role = useSelector(userRoleSelector, shallowEqual);
   const { id: userId } = useSelector(userInfoSelector, shallowEqual)!;
   const roadmapId = useSelector(chosenRoadmapIdSelector);
-  const fromPlanner = useSelector(fromMilestonesEditorSelector, shallowEqual);
+  const fromMilestonesEditorLink = useSelector(
+    fromMilestonesEditorSelector,
+    shallowEqual,
+  );
   const { value, complexity } = valueAndComplexitySummary(task);
   const {
     value: valueRatings,
@@ -226,9 +229,8 @@ const TaskOverview: FC<{
     <div className="overviewContainer">
       <Overview
         backHref={
-          fromPlanner
-            ? `${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.planner}${paths.plannerRelative.editor}`
-            : `${tasksPage}${paths.tasksRelative.tasklist}`
+          fromMilestonesEditorLink ||
+          `${tasksPage}${paths.tasksRelative.tasklist}`
         }
         overviewType={t('Task')}
         name={task.name}

--- a/frontend/src/pages/TaskOverviewPage.tsx
+++ b/frontend/src/pages/TaskOverviewPage.tsx
@@ -15,7 +15,10 @@ import {
 } from '../utils/TaskUtils';
 import { BusinessIcon, WorkRoundIcon } from '../components/RoleIcons';
 import { userInfoSelector, userRoleSelector } from '../redux/user/selectors';
-import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
+import {
+  chosenRoadmapIdSelector,
+  fromMilestonesEditorSelector,
+} from '../redux/roadmaps/selectors';
 import { RoadmapUser, Task } from '../redux/roadmaps/types';
 import { paths } from '../routers/paths';
 import { RatingTableComplexity } from '../components/RatingTableComplexity';
@@ -174,6 +177,7 @@ const TaskOverview: FC<{
   const role = useSelector(userRoleSelector, shallowEqual);
   const { id: userId } = useSelector(userInfoSelector, shallowEqual)!;
   const roadmapId = useSelector(chosenRoadmapIdSelector);
+  const fromPlanner = useSelector(fromMilestonesEditorSelector, shallowEqual);
   const { value, complexity } = valueAndComplexitySummary(task);
   const {
     value: valueRatings,
@@ -221,7 +225,11 @@ const TaskOverview: FC<{
   return (
     <div className="overviewContainer">
       <Overview
-        backHref={`${tasksPage}${paths.tasksRelative.tasklist}`}
+        backHref={
+          fromPlanner
+            ? `${paths.roadmapHome}/${roadmapId}${paths.roadmapRelative.planner}${paths.plannerRelative.editor}`
+            : `${tasksPage}${paths.tasksRelative.tasklist}`
+        }
         overviewType={t('Task')}
         name={task.name}
         previousAndNext={siblingTasks}

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -5,12 +5,15 @@ import {
   CLEAR_CURRENT_ROADMAP,
   SET_TASKMAP_POSITION,
   CLEAR_TASKMAP_POSITION,
+  SET_FROM_MILESTONES_EDITOR,
+  CLEAR_FROM_MILESTONES_EDITOR,
 } from './reducers';
 import { RoadmapsState } from './types';
 
 const initialState: RoadmapsState = {
   selectedRoadmapId: null,
   taskmapPosition: undefined,
+  fromMilestonesEditor: false,
 };
 
 export const roadmapsSlice = createSlice({
@@ -21,6 +24,8 @@ export const roadmapsSlice = createSlice({
     clearCurrentRoadmap: CLEAR_CURRENT_ROADMAP,
     setTaskmapPosition: SET_TASKMAP_POSITION,
     clearTaskmapPosition: CLEAR_TASKMAP_POSITION,
+    setFromMilestonesEditor: SET_FROM_MILESTONES_EDITOR,
+    clearFromMilestonesEditor: CLEAR_FROM_MILESTONES_EDITOR,
   },
 });
 

--- a/frontend/src/redux/roadmaps/index.ts
+++ b/frontend/src/redux/roadmaps/index.ts
@@ -13,7 +13,7 @@ import { RoadmapsState } from './types';
 const initialState: RoadmapsState = {
   selectedRoadmapId: null,
   taskmapPosition: undefined,
-  fromMilestonesEditor: false,
+  fromMilestonesEditor: undefined,
 };
 
 export const roadmapsSlice = createSlice({

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -22,3 +22,15 @@ export const SET_TASKMAP_POSITION: CaseReducer<
 export const CLEAR_TASKMAP_POSITION: CaseReducer<RoadmapsState> = (state) => {
   state.taskmapPosition = undefined;
 };
+
+export const SET_FROM_MILESTONES_EDITOR: CaseReducer<RoadmapsState> = (
+  state,
+) => {
+  state.fromMilestonesEditor = true;
+};
+
+export const CLEAR_FROM_MILESTONES_EDITOR: CaseReducer<RoadmapsState> = (
+  state,
+) => {
+  state.fromMilestonesEditor = false;
+};

--- a/frontend/src/redux/roadmaps/reducers.ts
+++ b/frontend/src/redux/roadmaps/reducers.ts
@@ -23,14 +23,15 @@ export const CLEAR_TASKMAP_POSITION: CaseReducer<RoadmapsState> = (state) => {
   state.taskmapPosition = undefined;
 };
 
-export const SET_FROM_MILESTONES_EDITOR: CaseReducer<RoadmapsState> = (
-  state,
-) => {
-  state.fromMilestonesEditor = true;
+export const SET_FROM_MILESTONES_EDITOR: CaseReducer<
+  RoadmapsState,
+  PayloadAction<string>
+> = (state, action) => {
+  state.fromMilestonesEditor = action.payload;
 };
 
 export const CLEAR_FROM_MILESTONES_EDITOR: CaseReducer<RoadmapsState> = (
   state,
 ) => {
-  state.fromMilestonesEditor = false;
+  state.fromMilestonesEditor = undefined;
 };

--- a/frontend/src/redux/roadmaps/selectors.ts
+++ b/frontend/src/redux/roadmaps/selectors.ts
@@ -5,3 +5,6 @@ export const chosenRoadmapIdSelector = (state: RootState) =>
 
 export const taskmapPositionSelector = (state: RootState) =>
   state.roadmaps.taskmapPosition;
+
+export const fromMilestonesEditorSelector = (state: RootState) =>
+  state.roadmaps.fromMilestonesEditor;

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -8,7 +8,7 @@ import {
 export interface RoadmapsState {
   selectedRoadmapId?: number | null;
   taskmapPosition: TaskmapPosition | undefined;
-  fromMilestonesEditor?: boolean;
+  fromMilestonesEditor?: string;
 }
 
 export interface Customer {

--- a/frontend/src/redux/roadmaps/types.ts
+++ b/frontend/src/redux/roadmaps/types.ts
@@ -8,6 +8,7 @@ import {
 export interface RoadmapsState {
   selectedRoadmapId?: number | null;
   taskmapPosition: TaskmapPosition | undefined;
+  fromMilestonesEditor?: boolean;
 }
 
 export interface Customer {


### PR DESCRIPTION
If user has navigated to TaskOverview from RelationsModal link, the back-button takes the user back to MilestonesEditor (with the same RelationsModal open)