### PR TITLE
Fix having to refresh for sockets to work

### DIFF
--- a/server/src/utils/socketIoUtils.ts
+++ b/server/src/utils/socketIoUtils.ts
@@ -45,9 +45,12 @@ export const setSubscribedRoadmap = (socket: ExtendedSocket) => async (
   roadmapId: number | undefined | null,
   sendResponse?: (res: SocketStatusResponse) => void,
 ) => {
-  // -1 or no roadmapId arg leaves all rooms
+  socket.rooms.forEach((room) => {
+    if (room.startsWith('roadmap-')) {
+      socket.leave(room);
+    }
+  });
   if (!roadmapId || roadmapId === -1) {
-    socket.rooms.forEach((room) => socket.leave(room));
     sendResponse?.({ status: 200 });
     return;
   }
@@ -63,12 +66,6 @@ export const setSubscribedRoadmap = (socket: ExtendedSocket) => async (
     });
     return;
   }
-
-  socket.rooms.forEach((room) => {
-    if (room.startsWith('roadmap-')) {
-      socket.leave(room);
-    }
-  });
   socket.join(`roadmap-${roadmapId}`);
 
   sendResponse?.({ status: 200 });


### PR DESCRIPTION
Websocket refresh only worked if you refreshed the page while you had a roadmap selected - socket communication relies on users being added in rooms corresponding to their userId when they connect, and the server was making them leave those rooms when no roadmap was selected.