### PR TITLE
Show info for unordered tasks

### DIFF
--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -660,7 +660,7 @@ export const MilestonesEditor = () => {
             disableDragging={disableDrag || !hasVersionEditPermission}
             className={classes({ 'loading-cursor': disableDrag })}
             hideDragIndicator={!hasVersionEditPermission}
-            showRatings
+            showInfoIcon
             showSearch
           />
         </ExpandableColumn>


### PR DESCRIPTION
Showing both felt quite cramped, so I just left out the ratings as those are also found in the tooltip.

The disadvantage is that it's no longer easy to look through all the tasks in the list, as one must open the tooltip first.
For that some indication of the important tasks could be useful, so the user knows which tooltips to check.