### PR TITLE
Fix topbar shrinking behaviour

### DIFF
--- a/frontend/src/shared.scss
+++ b/frontend/src/shared.scss
@@ -188,6 +188,7 @@ form {
   background-color: white;
   border-radius: 52px;
   margin-bottom: 45px;
+  min-width: min-content;
 
   &.topMargin {
     margin-top: 20px;


### PR DESCRIPTION
TopBar was shrinking too much with (really) small screen width and contents of the TopBar overflowed, setting min-width: min-content for .topBar fixes the issue