### PR TITLE
Fix text overflows

### DIFF
--- a/frontend/src/components/MissingRatings.module.scss
+++ b/frontend/src/components/MissingRatings.module.scss
@@ -16,6 +16,13 @@
   }
 }
 
+.missingTooltip {
+  width: 100%;
+  word-wrap: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .withLabel {
   @extend .typography-pre-title;
   @extend .layout-row;

--- a/frontend/src/components/MissingRatings.tsx
+++ b/frontend/src/components/MissingRatings.tsx
@@ -76,13 +76,16 @@ export const MissingRatings: FC<{
           }}
           key={customer.id}
           title={
-            <div>
+            <div className={classes(css.missingTooltip)}>
               <p className={classes(css.titleHeader)}>{customer.name}</p>
               <div className={classes(css.emailList)}>
                 {allUsers &&
                   getMissingRepresentatives(customer, allUsers, task)?.map(
                     (rep) => (
-                      <div key={`${rep.id}-${customer.id}-${task.id}`}>
+                      <div
+                        key={`${rep.id}-${customer.id}-${task.id}`}
+                        className={classes(css.missingTooltip)}
+                      >
                         {rep.email}{' '}
                         {rep.email === userInfo?.email && (
                           <span>
@@ -111,7 +114,7 @@ export const MissingRatings: FC<{
               tooltip: classes(css.tooltip),
             }}
             key={email}
-            title={email}
+            title={<div className={classes(css.missingTooltip)}>{email}</div>}
             placement="top"
             arrow
           >

--- a/frontend/src/components/TaskTable.module.scss
+++ b/frontend/src/components/TaskTable.module.scss
@@ -1,10 +1,21 @@
 @import '../shared.scss';
 @import './TaskMapTask.module.scss';
 
-// Bottom and top left radius for clean looking hover
-.ratedTitle {
-  padding-left: 25px;
+.taskTitle {
+  @extend .taskNameContainer;
+  width: auto;
+  overflow: hidden;
+  padding-top: 0;
+  padding-bottom: 0;
+
+  line-height: 1.5;
   text-align: left;
+  overflow-wrap: break-word;
+}
+
+.ratedTitle {
+  @extend .taskTitle;
+  padding-left: 25px;
 }
 
 .ratedButtons {
@@ -42,11 +53,6 @@
 .missingRatings {
   display: flex;
   align-items: center;
-}
-
-.taskTitle {
-  text-align: left;
-  overflow-wrap: break-word;
 }
 
 .userIcon {


### PR DESCRIPTION
- Limited the task list page titles to 2 lines, and added bit more line height.
- The rating tooltip text overflow is now hidden (using `ellipsis` to give some indication that the full email isn't shown)