### PR TITLE
Remove unnecessary scrollbars on milestone editor page

### DIFF
--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -144,9 +144,9 @@
 }
 
 .topbar {
+  @extend .layout-row;
+  min-height: 60px;
   overflow-x: auto;
-  display: flex;
-  flex-direction: row;
   align-items: center;
   border-bottom: 1px solid $COLOR_BLACK40;
   margin-left: 23px;

--- a/frontend/src/pages/MilestonesEditor.module.scss
+++ b/frontend/src/pages/MilestonesEditor.module.scss
@@ -67,12 +67,19 @@
   }
 }
 
+.milestoneContainer {
+  @extend .layout-row;
+  flex-grow: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .milestoneWrapper {
   @extend .shadow-roadmapblock;
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-height: 330px;
+  min-height: 600px;
   width: 270px;
   border-radius: 10px;
   background-color: white;
@@ -137,6 +144,7 @@
 }
 
 .topbar {
+  overflow-x: auto;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -664,9 +664,9 @@ export const MilestonesEditor = () => {
             showSearch
           />
         </ExpandableColumn>
-        <div className={classes(css.layoutCol, css.overflowYAuto)}>
+        <div className={classes(css.layoutCol)}>
           {renderTopBar()}
-          <div className={classes(css.layoutRow, css.overflowYAuto)}>
+          <div className={classes(css.milestoneContainer)}>
             {versionLists && renderMilestones()}
             <Drawer
               anchor="right"


### PR DESCRIPTION
Now the topbar section is independently scrollable and there should be only one horizontal bar at the bottom.

Also added larger minimum height for the milestones, as the content
would overflow on the previous minimum.