### PR TITLE
Hide overflowing "waiting for ratings" dots

### DIFF
--- a/frontend/src/components/MissingRatings.module.scss
+++ b/frontend/src/components/MissingRatings.module.scss
@@ -2,6 +2,8 @@
 
 .missingContainer {
   @extend .layout-row;
+  max-height: 40px;
+  overflow: hidden;
   gap: 7px;
   flex-wrap: wrap;
 


### PR DESCRIPTION
The column has room for minimum of 6 dots.

Showing the number of hidden dots might be "nice to have" option, but I'm not sure if that would be reasonable to implement.