### PR TITLE
Fix leave roadmap

### DIFF
--- a/frontend/src/components/modals/LeaveRoadmapModal.tsx
+++ b/frontend/src/components/modals/LeaveRoadmapModal.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as AlertIcon } from '../../icons/alert_icon.svg';
 import '../../shared.scss';
 import { RoleType } from '../../../../shared/types/customTypes';
 import { userInfoSelector } from '../../redux/user/selectors';
+import { chosenRoadmapIdSelector } from '../../redux/roadmaps/selectors';
 import { getType } from '../../utils/UserUtils';
 import { apiV2, selectById } from '../../api/api';
 
@@ -24,6 +25,7 @@ export const LeaveRoadmapModal: Modal<ModalTypes.LEAVE_ROADMAP_MODAL> = ({
   const dispatch = useDispatch<StoreDispatchType>();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const currentRoadmapId = useSelector(chosenRoadmapIdSelector);
   const userInfo = useSelector(userInfoSelector);
   const { data: roadmap } = apiV2.useGetRoadmapsQuery(
     undefined,
@@ -52,6 +54,8 @@ export const LeaveRoadmapModal: Modal<ModalTypes.LEAVE_ROADMAP_MODAL> = ({
       if (res.payload?.message) return setErrorMessage(res.payload.message);
       return;
     }
+    if (currentRoadmapId === roadmapId)
+      dispatch(roadmapsActions.clearCurrentRoadmap());
     closeModal();
   };
 

--- a/frontend/src/redux/roadmaps/actions.ts
+++ b/frontend/src/redux/roadmaps/actions.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
 import { userActions } from '../user/index';
-import { api } from '../../api/api';
+import { api, apiV2 } from '../../api/api';
 import { Task } from './types';
 
 export const notifyUsers = createAsyncThunk<
@@ -26,6 +26,7 @@ export const leaveRoadmap = createAsyncThunk<
     const success = await api.leaveRoadmap(leaveRoadmapRequest.roadmapId);
     if (success) {
       await thunkAPI.dispatch(userActions.getUserInfo());
+      await thunkAPI.dispatch(apiV2.endpoints.refetchRoadmaps.initiate());
     }
     return success;
   } catch (err) {


### PR DESCRIPTION
Fixes two things related to leaving a roadmap:
1. If the same roadmap was selected, unselect the roadmap
2. Refetch roadmaps (RoadmapSelectorWidget was not updated after
leaving a roadmap)