### PR TITLE
Add route authorization

### DIFF
--- a/frontend/src/routers/PlannerPageRouter.tsx
+++ b/frontend/src/routers/PlannerPageRouter.tsx
@@ -7,6 +7,7 @@ import { MilestonesEditor } from '../pages/MilestonesEditor';
 import { PlannerWeightsPage } from '../pages/PlannerWeightsPage';
 import { RoadmapGraphPage } from '../pages/RoadmapGraphPage';
 import { TimeEstimationPage } from '../pages/TimeEstimationPage';
+import { requireRoadmapPermission } from '../utils/requirelogin';
 import { Permission } from '../../../shared/types/customTypes';
 import { hasPermission } from '../../../shared/utils/permission';
 import { paths } from './paths';
@@ -30,7 +31,10 @@ const routes = [
   },
   {
     path: paths.plannerRelative.weights,
-    component: PlannerWeightsPage,
+    component: requireRoadmapPermission(
+      PlannerWeightsPage,
+      Permission.RoadmapReadCustomerValues,
+    ),
     exact: false,
   },
   {

--- a/frontend/src/routers/RoadmapRouter.tsx
+++ b/frontend/src/routers/RoadmapRouter.tsx
@@ -16,13 +16,18 @@ import { ClientOverviewPage } from '../pages/ClientOverviewPage';
 import { StoreDispatchType } from '../redux';
 import { roadmapsActions } from '../redux/roadmaps';
 import { chosenRoadmapIdSelector } from '../redux/roadmaps/selectors';
-import { requireVerifiedEmail } from '../utils/requirelogin';
+import {
+  requireRoadmapPermission,
+  requireRoadmapRole,
+  requireVerifiedEmail,
+} from '../utils/requirelogin';
 import { paths } from './paths';
 import { PlannerPageRouter } from './PlannerPageRouter';
 import { TasksPageRouter } from './TasksPageRouter';
 import '../shared.scss';
 import { usePrevious } from '../utils/usePrevious';
 import { apiV2, selectById } from '../api/api';
+import { Permission, RoleType } from '../../../shared/types/customTypes';
 
 const routes = [
   {
@@ -31,7 +36,7 @@ const routes = [
   },
   {
     path: paths.roadmapRelative.team,
-    component: TeamListPage,
+    component: requireRoadmapRole(TeamListPage, [RoleType.Admin]),
   },
   {
     path: paths.roadmapRelative.tasks,
@@ -43,15 +48,21 @@ const routes = [
   },
   {
     path: paths.roadmapRelative.clients,
-    component: ClientsListPage,
+    component: requireRoadmapRole(ClientsListPage, [
+      RoleType.Admin,
+      RoleType.Business,
+    ]),
   },
   {
     path: paths.roadmapRelative.planner,
-    component: PlannerPageRouter,
+    component: requireRoadmapPermission(
+      PlannerPageRouter,
+      Permission.VersionRead,
+    ),
   },
   {
     path: paths.roadmapRelative.settings,
-    component: ConfigurationPage,
+    component: requireRoadmapRole(ConfigurationPage, [RoleType.Admin]),
   },
   {
     path: '',

--- a/frontend/src/utils/requirelogin.tsx
+++ b/frontend/src/utils/requirelogin.tsx
@@ -1,10 +1,12 @@
 import { FC, ComponentType, useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Redirect, useLocation, matchPath } from 'react-router-dom';
+import { hasPermission } from '../../../shared/utils/permission';
+import { Permission, RoleType } from '../../../shared/types/customTypes';
 import { StoreDispatchType } from '../redux';
 import { RootState } from '../redux/types';
 import { userActions } from '../redux/user';
-import { userInfoSelector } from '../redux/user/selectors';
+import { userInfoSelector, userRoleSelector } from '../redux/user/selectors';
 import { UserInfo } from '../redux/user/types';
 import { paths } from '../routers/paths';
 
@@ -71,3 +73,22 @@ export function requireVerifiedEmail<T>(
     );
   });
 }
+
+export const requireRoadmapRole = <T,>(
+  Component: ComponentType<T>,
+  required: RoleType[],
+): FC<T> => (props) => {
+  const role = useSelector(userRoleSelector, shallowEqual);
+  if (!role || !required.includes(role))
+    return <Redirect to={paths.notFound} />;
+  return <Component {...props} />;
+};
+
+export const requireRoadmapPermission = <T,>(
+  Component: ComponentType<T>,
+  required: Permission,
+): FC<T> => (props) => {
+  const role = useSelector(userRoleSelector, shallowEqual);
+  if (!hasPermission(role, required)) return <Redirect to={paths.notFound} />;
+  return <Component {...props} />;
+};


### PR DESCRIPTION
https://trello.com/c/7zZHCnY1/681-lis%C3%A4%C3%A4-route-authorization
RequireRole and requirePermission can be used in roadmap routes to require a certain role or permission in order to access the route. If the condition is not met, user is redirected to 404 page.