### PR TITLE
Add word-break to customer names in planner weights page

### DIFF
--- a/frontend/src/pages/PlannerWeightsPage.module.scss
+++ b/frontend/src/pages/PlannerWeightsPage.module.scss
@@ -46,8 +46,10 @@
 
   .customer {
     min-width: 320px;
+    max-width: 320px;
     text-align: start;
     padding: 24px 0;
+    word-break: break-word;
   }
 
   .slider {


### PR DESCRIPTION
Long customer names would overflow so I added word-break there. I also added max-width for the container as the overflow could cause it to change width (Even with the word-break in use)

**Before:**
![image](https://user-images.githubusercontent.com/80753884/174757454-b0a038d3-7f00-4356-869a-5ddd4cc6731b.png)


**After:**
![image](https://user-images.githubusercontent.com/80753884/174757554-d9d6dcdc-7886-4cff-8769-a5e454bfd710.png)


