### PR TITLE
Change vertical alignment of the metrics from center to start

### DIFF
--- a/frontend/src/components/modals/VersionDetailsModal.module.scss
+++ b/frontend/src/components/modals/VersionDetailsModal.module.scss
@@ -25,7 +25,6 @@
   @extend .layout-row;
   gap: 10px;
   height: max-content;
-  align-items: center;
   justify-content: center;
   div {
     white-space: normal !important;


### PR DESCRIPTION
https://trello.com/c/Xtl90lFy/724-plan-roadmap-sidebarin-metrics-vertikaalinen-linjaus-flex-startiksi

Did the card mean this change? Removing the defined `align-items: center` should be enough here if that's what it meant

**Before:**

![image](https://user-images.githubusercontent.com/80753884/174812458-7c6861b0-ac7b-45f4-97a6-4ba5ce8fad7d.png)

**After:**

![image](https://user-images.githubusercontent.com/80753884/174812518-e3986c68-f591-4a67-9cff-2c8ce61f6ac2.png)
