### PR TITLE
Hide shares visualizations with only one client

### DIFF
--- a/frontend/src/components/modals/VersionDetailsModal.tsx
+++ b/frontend/src/components/modals/VersionDetailsModal.tsx
@@ -27,6 +27,7 @@ const numFormat = new Intl.NumberFormat(undefined, {
 
 export const VersionDetailsModal: Modal<ModalTypes.VERSION_DETAILS_MODAL> = ({
   version,
+  showShares,
   closeModal,
 }) => {
   const { t } = useTranslation();
@@ -118,29 +119,31 @@ export const VersionDetailsModal: Modal<ModalTypes.VERSION_DETAILS_MODAL> = ({
             </div>
           </div>
           <hr />
-          <div className={classes(css.shares)}>
-            <div
-              className={classes(css.lines)}
-              style={{ ['--bar-height' as any]: `${visualizationHeight}px` }}
-            >
-              {[1, 0.75, 0.5, 0.25, 0].map((p) => (
-                <div key={p}>
-                  <span>{percent(0).format(p)}</span>
-                  <hr />
-                </div>
-              ))}
+          {showShares && (
+            <div className={classes(css.shares)}>
+              <div
+                className={classes(css.lines)}
+                style={{ ['--bar-height' as any]: `${visualizationHeight}px` }}
+              >
+                {[1, 0.75, 0.5, 0.25, 0].map((p) => (
+                  <div key={p}>
+                    <span>{percent(0).format(p)}</span>
+                    <hr />
+                  </div>
+                ))}
+              </div>
+              <div className={classes(css.visualization)}>
+                <TaskValueCreatedVisualization
+                  width={37}
+                  height={visualizationHeight}
+                  versions={[version]}
+                  key={version.id}
+                  noTooltip
+                  vertical
+                />
+              </div>
             </div>
-            <div className={classes(css.visualization)}>
-              <TaskValueCreatedVisualization
-                width={37}
-                height={visualizationHeight}
-                versions={[version]}
-                key={version.id}
-                noTooltip
-                vertical
-              />
-            </div>
-          </div>
+          )}
         </div>
       </ModalContent>
     </div>

--- a/frontend/src/components/modals/types.ts
+++ b/frontend/src/components/modals/types.ts
@@ -120,6 +120,7 @@ type OwnProps = {
   };
   [ModalTypes.VERSION_DETAILS_MODAL]: {
     version: VersionComplexityAndValues;
+    showShares: boolean;
   };
   [ModalTypes.TASK_MAP_INFO_MODAL]: {};
 };

--- a/frontend/src/pages/MilestonesEditor.tsx
+++ b/frontend/src/pages/MilestonesEditor.tsx
@@ -144,6 +144,7 @@ export const MilestonesEditor = () => {
   const [isDragging, setIsDragging] = useState(false);
   const [selectedVersions, setSelectedVersions] = useState<number[]>([]);
 
+  const multipleCustomers = (customers?.length || []) > 1;
   const versionsSelected = selectedVersions.length > 0;
   const visualizedVersions =
     (versionsSelected
@@ -373,39 +374,43 @@ export const MilestonesEditor = () => {
   const renderTopBar = () => {
     return (
       <div className={classes(css.topbar)}>
-        <div className={classes(css.topbarShares)}>
-          <div>
-            <Trans i18nKey="Actual weighted shares" />
-          </div>
-          {roadmapsVersions && (
-            <TaskValueCreatedVisualization
-              versions={visualizedVersions}
-              width={200}
-              height={20}
-              barWidth={20}
-            />
-          )}
-        </div>
-        {hasCustomerReadPermission && (
+        {multipleCustomers && (
           <>
             <div className={classes(css.topbarShares)}>
-              <Trans i18nKey="Target weighted shares" />
+              <div>
+                <Trans i18nKey="Actual weighted shares" />
+              </div>
               {roadmapsVersions && (
-                <CustomerWeightsVisualization
+                <TaskValueCreatedVisualization
+                  versions={visualizedVersions}
                   width={200}
                   height={20}
                   barWidth={20}
-                  light
                 />
               )}
             </div>
-            {roadmapsVersions && (
-              <Link
-                className={classes(css.clientWeightsLink, 'green')}
-                to={`/roadmap/${roadmapId}${paths.roadmapRelative.planner}${paths.plannerRelative.weights}`}
-              >
-                <Trans i18nKey="See client weights" />
-              </Link>
+            {hasCustomerReadPermission && (
+              <>
+                <div className={classes(css.topbarShares)}>
+                  <Trans i18nKey="Target weighted shares" />
+                  {roadmapsVersions && (
+                    <CustomerWeightsVisualization
+                      width={200}
+                      height={20}
+                      barWidth={20}
+                      light
+                    />
+                  )}
+                </div>
+                {roadmapsVersions && (
+                  <Link
+                    className={classes(css.clientWeightsLink, 'green')}
+                    to={`/roadmap/${roadmapId}${paths.roadmapRelative.planner}${paths.plannerRelative.weights}`}
+                  >
+                    <Trans i18nKey="See client weights" />
+                  </Link>
+                )}
+              </>
             )}
           </>
         )}
@@ -522,7 +527,7 @@ export const MilestonesEditor = () => {
                           showInfoIcon
                         />
                       )}
-                      {hasCustomerReadPermission && (
+                      {hasCustomerReadPermission && multipleCustomers && (
                         <div
                           className={classes(css.summaryWrapper, {
                             [css.completed]: completed,

--- a/frontend/src/pages/PlannerWeightsPage.tsx
+++ b/frontend/src/pages/PlannerWeightsPage.tsx
@@ -34,6 +34,7 @@ export const PlannerWeightsPage = () => {
 
   const [localCustomers, setLocalCustomers] = useState<Customer[]>([]);
   const [errorMessage, setErrorMessage] = useState('');
+  const multipleCustomers = (customers?.length || []) > 1;
 
   useEffect(() => {
     if (customers)
@@ -62,18 +63,20 @@ export const PlannerWeightsPage = () => {
             <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
           </InfoTooltip>
         </h2>
-        <div className={classes(css.clientShares)}>
-          <MetricsSummary label={t('Target weighted shares')} value={null}>
-            <div className={classes(css.visualizationWrapper)}>
-              <CustomerWeightsVisualization
-                width={180}
-                height={20}
-                barWidth={20}
-                light
-              />
-            </div>
-          </MetricsSummary>
-        </div>
+        {multipleCustomers && (
+          <div className={classes(css.clientShares)}>
+            <MetricsSummary label={t('Target weighted shares')} value={null}>
+              <div className={classes(css.visualizationWrapper)}>
+                <CustomerWeightsVisualization
+                  width={180}
+                  height={20}
+                  barWidth={20}
+                  light
+                />
+              </div>
+            </MetricsSummary>
+          </div>
+        )}
       </header>
       {errorMessage.length > 0 && (
         <Alert

--- a/frontend/src/pages/RoadmapGraphPage.tsx
+++ b/frontend/src/pages/RoadmapGraphPage.tsx
@@ -57,6 +57,7 @@ export const RoadmapGraphPage = () => {
   const { data: customers } = apiV2.useGetCustomersQuery(
     roadmapId ?? skipToken,
   );
+  const multipleCustomers = (customers?.length || []) > 1;
 
   const a = useRef<HTMLDivElement | null>(null);
   const b = useRef<HTMLDivElement>(null);
@@ -144,6 +145,7 @@ export const RoadmapGraphPage = () => {
             history.replace(
               modalDrawerLink(ModalTypes.VERSION_DETAILS_MODAL, {
                 version: versions![idx],
+                showShares: multipleCustomers,
               }),
             )
           }
@@ -215,51 +217,53 @@ export const RoadmapGraphPage = () => {
             </>
           )}
         </BlockGraph>
-        <div className={classes(css.footer)}>
-          <div
-            className={classes(
-              css.titleContainer,
-              css.lowerGraphTitleContainer,
-            )}
-          >
-            <h2 className={classes(css.graphTitle)}>
-              {t('customerStakesTitle')}
-            </h2>
-            <InfoTooltip title={t('Planner customerStakes tooltip')}>
-              <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
-            </InfoTooltip>
-          </div>
-          <div className={classes(css.stakesContainer)}>
+        {multipleCustomers && (
+          <div className={classes(css.footer)}>
             <div
-              className={classes(css.lines)}
-              style={{ ['--bar-height' as any]: `${height}px` }}
-            >
-              {[1, 0.75, 0.5, 0.25, 0].map((p) => (
-                <div key={p}>
-                  <span>{percent(0).format(p)}</span>
-                  <hr />
-                </div>
-              ))}
-            </div>
-            <BlockView
-              items={versions ?? []}
-              dimensions={dimensions}
-              limits={limits}
-              innerRef={b}
-              style={{ overflowX: 'hidden' }}
-            >
-              {({ item: ver, width }) => (
-                <TaskValueCreatedVisualization
-                  width={width}
-                  height={height}
-                  versions={[ver]}
-                  key={ver.id}
-                  vertical
-                />
+              className={classes(
+                css.titleContainer,
+                css.lowerGraphTitleContainer,
               )}
-            </BlockView>
+            >
+              <h2 className={classes(css.graphTitle)}>
+                {t('customerStakesTitle')}
+              </h2>
+              <InfoTooltip title={t('Planner customerStakes tooltip')}>
+                <InfoIcon className={classes(css.tooltipIcon, css.infoIcon)} />
+              </InfoTooltip>
+            </div>
+            <div className={classes(css.stakesContainer)}>
+              <div
+                className={classes(css.lines)}
+                style={{ ['--bar-height' as any]: `${height}px` }}
+              >
+                {[1, 0.75, 0.5, 0.25, 0].map((p) => (
+                  <div key={p}>
+                    <span>{percent(0).format(p)}</span>
+                    <hr />
+                  </div>
+                ))}
+              </div>
+              <BlockView
+                items={versions ?? []}
+                dimensions={dimensions}
+                limits={limits}
+                innerRef={b}
+                style={{ overflowX: 'hidden' }}
+              >
+                {({ item: ver, width }) => (
+                  <TaskValueCreatedVisualization
+                    width={width}
+                    height={height}
+                    versions={[ver]}
+                    key={ver.id}
+                    vertical
+                  />
+                )}
+              </BlockView>
+            </div>
           </div>
-        </div>
+        )}
       </div>
       <Drawer
         anchor="right"


### PR DESCRIPTION
One client always has 100% of "produced" values, so there is no need to show visualizations related to it