### PR TITLE
Add keys to columns in task map info-modal

### DIFF
--- a/frontend/src/components/modals/TaskMapInfoModal.tsx
+++ b/frontend/src/components/modals/TaskMapInfoModal.tsx
@@ -53,16 +53,17 @@ export const TaskMapInfoModal: Modal<ModalTypes.TASK_MAP_INFO_MODAL> = ({
             {!showOverview ? <ExpandMoreIcon /> : <ExpandLessIcon />}
           </h4>
           {showOverview &&
-            overviewColumns.map(({ Title, columns }) => (
-              <>
+            overviewColumns.map(({ title, columns }) => (
+              <div key={title}>
                 <div className={classes(css.columnTitle)}>
-                  <Title />
+                  <Trans i18nKey={title} />
                 </div>
-                {columns.map(({ Subtitle, Icon, Description }) => (
+                {columns.map(({ subtitle, Icon, description }) => (
                   <div
                     className={classes(css.overviewColumn, {
                       [css.icon]: Icon,
                     })}
+                    key={subtitle}
                   >
                     {Icon && (
                       <div className={classes(css.icon)}>
@@ -70,14 +71,14 @@ export const TaskMapInfoModal: Modal<ModalTypes.TASK_MAP_INFO_MODAL> = ({
                       </div>
                     )}
                     <div className={classes(css.subtitle)}>
-                      <Subtitle />
+                      <Trans i18nKey={subtitle} />
                     </div>
                     <div className={classes(css.description)}>
-                      <Description />
+                      <Trans i18nKey={description} />
                     </div>
                   </div>
                 ))}
-              </>
+              </div>
             ))}
           <hr className={classes(css.fullWidth)} />
         </div>
@@ -97,31 +98,31 @@ export const TaskMapInfoModal: Modal<ModalTypes.TASK_MAP_INFO_MODAL> = ({
             <>
               <Trans i18nKey="Task map actions description" />
               <div className={classes(css.actionIcons)}>
-                {actionIcons.map(({ Icon, Action }) => (
-                  <div className={classes(css.item)}>
-                    <Icon /> <Action />
+                {actionIcons.map(({ Icon, action }) => (
+                  <div key={action} className={classes(css.item)}>
+                    <Icon /> <Trans i18nKey={action} />
                   </div>
                 ))}
               </div>
-              {actionColumns.map(({ Title, columns }) => (
-                <>
+              {actionColumns.map(({ title, columns }) => (
+                <div key={title}>
                   <div className={classes(css.columnTitle)}>
-                    <Title />
+                    <Trans i18nKey={title} />
                   </div>
-                  {columns.map(({ Subtitle, Action, Description }) => (
-                    <div className={classes(css.actionColumn)}>
+                  {columns.map(({ subtitle, action, description }) => (
+                    <div className={classes(css.actionColumn)} key={subtitle}>
                       <div className={classes(css.subtitle)}>
-                        <Subtitle />
+                        <Trans i18nKey={subtitle} />
                       </div>
                       <div className={classes(css.description)}>
                         <span className={classes(css.highlight)}>
-                          <Action />{' '}
+                          <Trans i18nKey={action} />{' '}
                         </span>
-                        <Description />
+                        <Trans i18nKey={description} />
                       </div>
                     </div>
                   ))}
-                </>
+                </div>
               ))}
             </>
           )}

--- a/frontend/src/components/modals/modalparts/TaskMapInfoModalColumns.tsx
+++ b/frontend/src/components/modals/modalparts/TaskMapInfoModalColumns.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { Trans } from 'react-i18next';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import PanToolAltIcon from '@mui/icons-material/PanToolAlt';
@@ -8,57 +7,55 @@ import OpenWithIcon from '@mui/icons-material/OpenWith';
 import ZoomInIcon from '@mui/icons-material/ZoomIn';
 
 export const overviewColumns: {
-  Title: FC;
-  columns: { Subtitle: FC; Description: FC; Icon?: FC }[];
+  title: string;
+  columns: { subtitle: string; description: string; Icon?: FC }[];
 }[] = [
   {
-    Title: () => <Trans i18nKey="Task relations" />,
+    title: 'Task relations',
     columns: [
       {
-        Subtitle: () => <Trans i18nKey="Relations" />,
-        Description: () => <Trans i18nKey="Relations description" />,
+        subtitle: 'Relations',
+        description: 'Relations description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Synergies" />,
-        Description: () => <Trans i18nKey="Synergies description" />,
+        subtitle: 'Synergies',
+        description: 'Synergies description',
       },
     ],
   },
   {
-    Title: () => <Trans i18nKey="View" />,
+    title: 'View',
     columns: [
       {
-        Subtitle: () => <Trans i18nKey="Task map" />,
-        Description: () => <Trans i18nKey="Task map description" />,
+        subtitle: 'Task map',
+        description: 'Task map description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Task circles" />,
-        Description: () => <Trans i18nKey="Task circles description" />,
+        subtitle: 'Task circles',
+        description: 'Task circles description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Unstaged tasks list" />,
-        Description: () => <Trans i18nKey="Unstaged tasks list description" />,
+        subtitle: 'Unstaged tasks list',
+        description: 'Unstaged tasks list description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Task info" />,
-        Description: () => <Trans i18nKey="Task info description" />,
+        subtitle: 'Task info',
+        description: 'Task info description',
       },
     ],
   },
   {
-    Title: () => <Trans i18nKey="Screen functions" />,
+    title: 'Screen functions',
     columns: [
       {
         Icon: () => <FullscreenIcon />,
-        Subtitle: () => <Trans i18nKey="Fit groups into the viewport" />,
-        Description: () => <Trans i18nKey="Fit groups description" />,
+        subtitle: 'Fit groups into the viewport',
+        description: 'Fit groups description',
       },
       {
         Icon: () => <RestartAltIcon />,
-        Subtitle: () => <Trans i18nKey="Reset group positions" />,
-        Description: () => (
-          <Trans i18nKey="Reset group positions description" />
-        ),
+        subtitle: 'Reset group positions',
+        description: 'Reset group positions description',
       },
     ],
   },
@@ -66,44 +63,42 @@ export const overviewColumns: {
 
 export const actionColumns = [
   {
-    Title: () => (
-      <Trans i18nKey="Adding and removing task relations & Synergies" />
-    ),
+    title: 'Adding and removing task relations & Synergies',
     columns: [
       {
-        Subtitle: () => <Trans i18nKey="Add relation" />,
-        Action: () => <Trans i18nKey="Add relation action" />,
-        Description: () => <Trans i18nKey="Add relation description" />,
+        subtitle: 'Add relation',
+        action: 'Add relation action',
+        description: 'Add relation description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Remove relation" />,
-        Action: () => <Trans i18nKey="Remove relation action" />,
-        Description: () => <Trans i18nKey="Remove relation description" />,
+        subtitle: 'Remove relation',
+        action: 'Remove relation action',
+        description: 'Remove relation description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Add synergy" />,
-        Action: () => <Trans i18nKey="Add synergy action" />,
-        Description: () => <Trans i18nKey="Add synergy description" />,
+        subtitle: 'Add synergy',
+        action: 'Add synergy action',
+        description: 'Add synergy description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Remove synergy" />,
-        Action: () => <Trans i18nKey="Remove synergy actions" />,
-        Description: () => <Trans i18nKey="Remove synergy description" />,
+        subtitle: 'Remove synergy',
+        action: 'Remove synergy actions',
+        description: 'Remove synergy description',
       },
     ],
   },
   {
-    Title: () => <Trans i18nKey="Reorganizing the view and viewing info" />,
+    title: 'Reorganizing the view and viewing info',
     columns: [
       {
-        Subtitle: () => <Trans i18nKey="Move a task or group" />,
-        Action: () => <Trans i18nKey="Move a task or group action" />,
-        Description: () => <Trans i18nKey="Move a task or group description" />,
+        subtitle: 'Move a task or group',
+        action: 'Move a task or group action',
+        description: 'Move a task or group description',
       },
       {
-        Subtitle: () => <Trans i18nKey="Show task info" />,
-        Action: () => <Trans i18nKey="Show task info action" />,
-        Description: () => <Trans i18nKey="Show task info description" />,
+        subtitle: 'Show task info',
+        action: 'Show task info action',
+        description: 'Show task info description',
       },
     ],
   },
@@ -112,18 +107,18 @@ export const actionColumns = [
 export const actionIcons = [
   {
     Icon: () => <PanToolAltIcon />,
-    Action: () => <Trans i18nKey="Click or Click & drag" />,
+    action: 'Click or Click & drag',
   },
   {
     Icon: () => <PanToolIcon />,
-    Action: () => <Trans i18nKey="Grab (a task)" />,
+    action: 'Grab (a task)',
   },
   {
     Icon: () => <OpenWithIcon />,
-    Action: () => <Trans i18nKey="Move (a group)" />,
+    action: 'Move (a group)',
   },
   {
     Icon: () => <ZoomInIcon />,
-    Action: () => <Trans i18nKey="Zoom in and out (scroll wheel)" />,
+    action: 'Zoom in and out (scroll wheel)',
   },
 ];


### PR DESCRIPTION
The mapped divs were missing keys. I added a custom key to each object in `TaskMapInfoModalColumns.tsx`. Decided to go for this solution as you couldn't use the FC nor Translation elements directly as the key.